### PR TITLE
Error spec for error responses

### DIFF
--- a/test/kixi/integration/base.clj
+++ b/test/kixi/integration/base.clj
@@ -2,6 +2,7 @@
   (:require [byte-streams :as bs]
             [clojure.test :refer :all   ;:exclude [deftest]
              ]
+            [clojure.spec.test :as stest]
             [cheshire.core :as json]
             [kixi.repl :as repl]
             [kixi.datastore.transit :as t]
@@ -31,9 +32,14 @@
        (clojure.test/do-report {:type :error :message "Exception diffing"
                                 :expected nil :actual t#}))))
 
+(defn instrument-specd-functions
+  []
+  (stest/instrument 'kixi.datastore.web-server/return-error))
+
 (defn cycle-system-fixture
   [all-tests]
   (repl/start)
+  (instrument-specd-functions)
   (all-tests)
   (repl/stop))
 

--- a/test/kixi/integration/metadata_test.clj
+++ b/test/kixi/integration/metadata_test.clj
@@ -5,6 +5,7 @@
             [clojure.java.io :as io]
             [kixi.integration.base :refer :all]
             [kixi.datastore.metadatastore :as ms]
+            [kixi.datastore.web-server :as ws]
             [kixi.datastore.schemastore.conformers :as conformers]
             [kixi.datastore.schemastore :as ss]))
 
@@ -55,7 +56,7 @@
         ]
     (is-submap
      {:status 400
-      :body {:error "unknown-schema"}}
+      :body {::ws/error "unknown-schema"}}
      pfr)))
 
 (deftest small-file-invalid-data


### PR DESCRIPTION
This adds a fdef for error-response in the web-server. This function is
then instrumented in the tests, creating failures if any resource tries
to misuse this function.