### PR TITLE
Add new schema types to resolve-spec

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ machine:
     - docker
   environment:
     wait_tries: 200
-    generative_testing_size: 1000
+    generative_testing_size: 200
     _JAVA_OPTIONS: "-Xms248m -Xmx1024m"
 
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ machine:
     - docker
   environment:
     wait_tries: 200
-    generative_testing_size: 200
+    generative_testing_size: 100
     _JAVA_OPTIONS: "-Xms248m -Xmx1024m"
 
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,7 @@ machine:
     - docker
   environment:
     wait_tries: 200
+    generative_testing_size: 1000
     _JAVA_OPTIONS: "-Xms248m -Xmx1024m"
 
 test:

--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,6 @@
                  [clj-http "2.2.0"]
                  [clj-time "0.12.0"]
                  [clojure-csv/clojure-csv "2.0.1"]
-                 [criterium "0.4.4"]
                  [com.cognitect/transit-clj "0.8.288"]
                  [com.izettle/dropwizard-metrics-influxdb "1.1.6" :exclusions [ch.qos.logback/logback-classic]]
                  [com.fzakaria/slf4j-timbre "0.3.2"]
@@ -44,5 +43,7 @@
   :global-vars {*warn-on-reflection* true
                 *assert* false}
 
-  :profiles {:uberjar {:aot [kixi.datastore.bootstrap]
+  :profiles {:dev {:dependencies [[org.clojure/test.check "0.9.0"]
+                                  [criterium "0.4.4"]]}
+             :uberjar {:aot [kixi.datastore.bootstrap]
                        :uberjar-name "kixi.datastore-standalone.jar"}})

--- a/project.clj
+++ b/project.clj
@@ -44,6 +44,7 @@
                 *assert* false}
 
   :profiles {:dev {:dependencies [[org.clojure/test.check "0.9.0"]
+                                  [com.gfredericks/test.chuck "0.2.7"]
                                   [criterium "0.4.4"]]}
              :uberjar {:aot [kixi.datastore.bootstrap]
                        :uberjar-name "kixi.datastore-standalone.jar"}})

--- a/src/kixi/datastore/schemastore.clj
+++ b/src/kixi/datastore/schemastore.clj
@@ -60,6 +60,9 @@
 (defmethod schema-type "pattern" [_]
   (s/keys :req [::type ::pattern]))
 
+(defmethod schema-type "string" [_]
+  (s/keys :req [::type]))
+
 (s/def ::schema
   (s/multi-spec schema-type ::type))
 

--- a/src/kixi/datastore/schemastore.clj
+++ b/src/kixi/datastore/schemastore.clj
@@ -39,11 +39,26 @@
 (defmethod schema-type "integer" [_]
   (s/keys :req [::type]))
 
+(defmethod schema-type "double" [_]
+  (s/keys :req [::type]))
+
 (defmethod schema-type "id" [_]
   (s/keys :req [::type ::id]))
 
 (defmethod schema-type "integer-range" [_]
   (s/keys :req [::type ::min ::max]))
+
+(defmethod schema-type "double-range" [_]
+  (s/keys :req [::type ::min ::max]))
+
+(defmethod schema-type "set" [_]
+  (s/keys :req [::type ::elements]))
+
+(defmethod schema-type "boolean" [_]
+  (s/keys :req [::type]))
+
+(defmethod schema-type "pattern" [_]
+  (s/keys :req [::type ::pattern]))
 
 (s/def ::schema
   (s/multi-spec schema-type ::type))

--- a/src/kixi/datastore/schemastore/conformers.clj
+++ b/src/kixi/datastore/schemastore/conformers.clj
@@ -9,11 +9,19 @@
     (when (== int-val d)
       int-val)))
 
+(defn str->double
+  "Strings converted to doubles"
+  [^String s]
+  (try
+    (Double/valueOf (str s))
+    (catch Exception e
+      :clojure.spec/invalid)))
+
 (defn str-double->int
   "1, 1. or 1.0...0 will convert to 1"
   [^String s]
   (try
-    (double->int (Double/valueOf s))
+    (double->int (str->double s))
     (catch Exception e
       nil)))
 
@@ -48,10 +56,7 @@
   (cond
     (clojure.core/double? x) x
     (clojure.core/integer? x) (double x)
-    (string? x) (try
-                  (Double/valueOf (str x))
-                  (catch Exception e
-                    :clojure.spec/invalid))
+    (string? x) (str->double x)
     :else :clojure.spec/invalid))
 
 (def double? (s/conformer -double?))

--- a/src/kixi/datastore/schemastore/conformers.clj
+++ b/src/kixi/datastore/schemastore/conformers.clj
@@ -142,3 +142,9 @@
     :else :clojure.spec/invalid))
 
 (def bool? (s/conformer -bool?))
+
+(defn -string?
+  [x]
+  (cond
+    (string? x) x
+    :else (str x)))

--- a/src/kixi/datastore/schemastore/conformers.clj
+++ b/src/kixi/datastore/schemastore/conformers.clj
@@ -14,7 +14,7 @@
   [^String s]
   (try
     (double->int (Double/valueOf s))
-    (catch NumberFormatException e
+    (catch Exception e
       nil)))
 
 (defn str->int
@@ -50,7 +50,7 @@
     (clojure.core/integer? x) (double x)
     (string? x) (try
                   (Double/valueOf (str x))
-                  (catch NumberFormatException e
+                  (catch Exception e
                     :clojure.spec/invalid))
     :else :clojure.spec/invalid))
 
@@ -131,8 +131,9 @@
 
 (defn -bool?
   [x]
-  (if (string? x)
-    (Boolean/valueOf (str x))
-    :clojure.spec/invalid))
+  (cond
+    (boolean? x) x
+    (string? x) (Boolean/valueOf (str x))
+    :else :clojure.spec/invalid))
 
 (def bool? (s/conformer -bool?))

--- a/src/kixi/datastore/schemastore/validator.clj
+++ b/src/kixi/datastore/schemastore/validator.clj
@@ -54,6 +54,10 @@
   [definition _]
   (conformers/regex? (get-in definition [::ss/schema ::ss/pattern])))
 
+(defmethod resolve-schema "string"
+  [_ _]
+  conformers/-string?)
+
 (defn resolve-form
   [definition schemastore]
   (if-let [id (::ss/id definition)]

--- a/src/kixi/datastore/schemastore/validator.clj
+++ b/src/kixi/datastore/schemastore/validator.clj
@@ -24,6 +24,15 @@
   (let [{min ::ss/min max ::ss/max} (::ss/schema definition)]
     (conformers/integer-range? min max)))
 
+(defmethod resolve-schema "double"
+  [_ _]
+  conformers/double?)
+
+(defmethod resolve-schema "double-range"
+  [definition _]
+  (let [{min ::ss/min max ::ss/max} (::ss/schema definition)]
+    (conformers/double-range? min max)))
+
 (defmethod resolve-schema "id"
   [definition schemastore]
   (->
@@ -32,9 +41,18 @@
    ((partial ss/fetch-spec schemastore))
    (resolve-schema schemastore)))
 
+(defmethod resolve-schema "set"
+  [definition _]
+  (let [{elements ::ss/elements} (::ss/schema definition)]
+    (apply conformers/set? elements)))
+
 (defmethod resolve-schema "boolean"
   [_ _]
   conformers/bool?)
+
+(defmethod resolve-schema "pattern"
+  [definition _]
+  (conformers/regex? (get-in definition [::ss/schema ::ss/pattern])))
 
 (defn resolve-form
   [definition schemastore]

--- a/test/kixi/unit/schemastore/schemastore_test.clj
+++ b/test/kixi/unit/schemastore/schemastore_test.clj
@@ -6,7 +6,9 @@
             [kixi.comms :as c]
             [kixi.integration.base :refer :all]
             [com.stuartsierra.component :as component]
-            [clojure.test :refer :all]))
+            [clojure.test :refer :all]
+            [clojure.spec.gen :as gen]
+            [clojure.spec :as s]))
 
 (defonce system (atom nil))
 
@@ -21,29 +23,140 @@
 
 (defn wait-for-schema-id
   [id schemastore]
-  (loop [tries 30]
+  (loop [tries 40]
     (when-not (ss/fetch-spec schemastore id)
       (Thread/sleep 100)
       (if (zero? (dec tries))
         (throw (Exception. "Schema ID never appeared."))
         (recur (dec tries))))))
 
-(deftest submit-and-validate-schema
-  (let [{:keys [communications schemastore]} @system
-        id         (uuid)
-        schema-req {::ss/name ::foobar
-                    ::ss/schema {::ss/type "list"
-                                 ::ss/definition [:foo {::ss/type "integer"}
-                                                  :bar {::ss/type "integer"}
-                                                  :baz {::ss/type "integer-range"
-                                                        ::ss/min 3
-                                                        ::ss/max 10}]}
-                    ::ss/id id}]
-    (c/send-event! communications :kixi.datastore/schema-created "1.0.0" schema-req)
-    (wait-for-schema-id id schemastore)
-    (is (is-submap schema-req (ss/fetch-spec schemastore id)))
-    (is (sv/valid? schemastore id [1 2 5]))
-    (is (sv/valid? schemastore id [(+ 1 1) 2 5]))
-    (is (sv/valid? schemastore id ["1" "2" "5"]))
-    (is (not (sv/valid? schemastore id [1 2 2])))
-    (is (not (sv/valid? schemastore id ["1" "2" "2"])))))
+(def gen-int (s/gen (s/or :int integer?
+                          :str string?)
+                    {[:str] #(gen/fmap str (gen/int))}))
+
+(defn gen-int-range 
+  "Our int-ranges are inclusive at both ends, hence the inc's"
+  [min max]
+  (s/gen (s/or :int (s/int-in min (inc max))
+               :str string?)
+         {[:str] #(gen/fmap str (s/gen (s/int-in min (inc max))))}))
+
+(def gen-double (s/gen (s/or :dbl double?
+                             :str string?)
+                       {[:str] #(gen/fmap str (gen/double))}))
+
+(defn gen-double-range 
+  [& {:keys [min max]}]
+  (s/gen (s/or :int (s/double-in :min min :max max)
+               :str string?)
+         {[:str] #(gen/fmap str (s/gen (s/double-in :min min :max max)))}))
+
+(defn gen-set
+  [elements]
+  (s/gen (set elements)))
+
+(def gen-bool
+  (s/gen (s/or :bool (gen/boolean)
+               :str  string?)
+         {[:str] #()}))
+
+(def sample-size 100)
+
+(defmacro test-schema
+  [schema-name schema-def good-generator bad-generator]
+  `(let [{communications# :communications schemastore# :schemastore} (deref system)
+         id#         (uuid)
+         schema-req# {::ss/name ~schema-name
+                      ::ss/schema ~schema-def
+                      ::ss/id id#}]
+     (c/send-event! communications# :kixi.datastore/schema-created "1.0.0" schema-req#)
+     (wait-for-schema-id id# schemastore#)
+     (is-submap schema-req# (ss/fetch-spec schemastore# id#))
+     (doseq [gd# (gen/sample ~good-generator sample-size)]
+       (is (nil? (sv/explain-data schemastore# id# gd#))))
+     (doseq [bd# (gen/sample ~bad-generator sample-size)]
+       (is (get (sv/explain-data schemastore# id# bd#) ::s/problems)))))
+
+(deftest integer-list
+  (test-schema ::list-one-integer
+               {::ss/type "list"
+                ::ss/definition [:integer {::ss/type "integer"}]}
+               (gen/tuple gen-int)
+               (gen/tuple (gen/fmap 
+                           #(if (re-matches #"[0-9]+" %)
+                              (str % "x")
+                              %)
+                           (s/gen string?)))))
+
+(deftest integer-range-list
+  (let [min 3
+        max 20]
+    (test-schema ::list-one-integer
+                 {::ss/type "list"
+                  ::ss/definition [:integer-range {::ss/type "integer-range"
+                                                   ::ss/min min
+                                                   ::ss/max max}]}
+                 (gen/tuple (gen-int-range min max))
+                 (gen/tuple (s/gen (s/or :lower int?
+                                         :higher int?)
+                                   {[:lower] #(gen-int-range Integer/MIN_VALUE (dec min))
+                                    [:higher] #(gen-int-range (inc max) (dec Integer/MAX_VALUE))})))))
+
+(deftest double-list
+  (test-schema ::list-one-double
+               {::ss/type "list"
+                ::ss/definition [:double {::ss/type "double"}]}
+               (gen/tuple gen-double)
+               (gen/tuple (gen/fmap 
+                           #(if (re-matches #"[0-9]+" %)
+                              (str % "x")
+                              %)
+                           (s/gen string?)))))
+
+(deftest double-range-list
+  (let [min -10.3
+        max 10.6]
+    (test-schema ::list-one-double-range
+                 {::ss/type "list"
+                  ::ss/definition [:double-range {::ss/type "double-range"
+                                                  ::ss/min min
+                                                  ::ss/max max}]}
+                 (gen/tuple (gen-double-range :min min :max max))
+                 (gen/tuple (s/gen nil?)))))
+(comment
+  "This should be the bad data generator for double-range-list, but it just doesn't work"
+  (gen/tuple (s/gen (s/or :lower double?
+                          :higher double?)
+                    {[:lower] #(gen-double-range :max (+ max 0.1))
+                     [:higher] #(gen-double-range :min (- min 0.1))})))
+
+(deftest sets
+  (let [elements [1 2 3 4]
+        not-in-elements "a"]
+    (test-schema ::list-set
+                 {::ss/type "list"
+                  ::ss/definition [:set {::ss/type "set"
+                                         ::ss/elements elements}]}
+                 (gen/tuple (gen-set [1 2 3 4]))
+                 (gen/tuple (gen/fmap 
+                             #(if ((set elements) %)
+                                not-in-elements
+                                %)
+                             (gen/any))))))
+
+(deftest bool-list
+  (test-schema ::list-one-bool
+               {::ss/type "list"
+                ::ss/definition [:boolean {::ss/type "boolean"}]}
+               (gen/tuple (s/gen (s/or :bool boolean?
+                                       :str string?)))
+               (gen/tuple (s/gen nil?))))
+
+(deftest regex-list
+  "Very hard to test regex's, just a dummy example will have to do"
+  (test-schema ::list-one-regex
+               {::ss/type "list"
+                ::ss/definition [:regex {::ss/type "pattern"
+                                         ::ss/pattern "-?[0-9]+"}]}
+               (gen/tuple (gen/fmap str (s/gen int?)))
+               (gen/tuple (gen/char-alpha))))

--- a/test/kixi/unit/schemastore/schemastore_test.clj
+++ b/test/kixi/unit/schemastore/schemastore_test.clj
@@ -162,3 +162,10 @@
                                          ::ss/pattern "-?[0-9]+"}]}
                (gen/tuple (gen/fmap str (s/gen int?)))
                (gen/tuple (gen/char-alpha))))
+
+(deftest string-list
+  (test-schema ::list-one-string
+               {::ss/type "list"
+                ::ss/definition [:string {::ss/type "string"}]}
+               (gen/tuple (s/gen string?))
+               (s/gen nil?)))

--- a/test/kixi/unit/schemastore/schemastore_test.clj
+++ b/test/kixi/unit/schemastore/schemastore_test.clj
@@ -55,7 +55,7 @@
                :str  string?)
          {[:str] #()}))
 
-(def sample-size (env :generative-testing-size 100))
+(def sample-size (Integer/valueOf (env :generative-testing-size "100")))
 
 (defn double-str? 
   [^String s]


### PR DESCRIPTION
Adding them there allows them to be actually used.

Expanded the test suite for this massively with a suite of generative
tests that explore the boundaries of our spec elements.