### PR TITLE
Moved file metadata on upload to a json map

### DIFF
--- a/src/kixi/datastore/metadatastore.clj
+++ b/src/kixi/datastore/metadatastore.clj
@@ -2,10 +2,10 @@
   (:require [clojure.spec :as s]
             [kixi.datastore.schemastore :as schemastore]
             [kixi.datastore.segmentation :as seg]
-            [kixi.datastore.schemastore.conformers :as sc]))
+            [kixi.datastore.schemastore.conformers :as sc :refer [uuid]]))
 
 (s/def ::type #{"csv"})
-(s/def ::id string?)
+(s/def ::id uuid)
 (s/def ::parent-id ::id)
 (s/def ::pieces-count int?)
 (s/def ::name string?)
@@ -33,7 +33,7 @@
 
 (defmethod provenance-type "segmentation"
   [_]
-  (s/keys :req [::source ::line-count ::seg/request ::parent-id]))
+  (s/keys :req [::source ::parent-id]))
 
 (s/def ::provenance (s/multi-spec provenance-type ::source))
 
@@ -47,7 +47,7 @@
 
 (s/def ::segmentation
   (s/keys :req [:kixi.datastore.request/request ::seg/created]
-          :opt [::seg/msg ::seg/segment-ids]))
+          :opt [::seg/error ::seg/segment-ids]))
 
 (s/def ::segmentations
   (s/cat :segmentations (s/+ ::segmentation)))
@@ -64,7 +64,7 @@
   (s/keys :req [::valid]
           :opt [::explain]))
 
-(s/def ::filemetadata
+(s/def ::file-metadata
   (s/keys :req [::type ::id ::name ::schemastore/id ::provenance ::size-bytes]
           :opt [::segmentations ::segment ::structural-validation]))
 

--- a/src/kixi/datastore/schemastore.clj
+++ b/src/kixi/datastore/schemastore.clj
@@ -1,27 +1,8 @@
 (ns kixi.datastore.schemastore
   (:require [clojure.spec :as s]
-            [clj-time.core :as t]
-            [clj-time.format :as tf]
-            [kixi.datastore.schemastore.conformers :as sc]))
+            [kixi.datastore.schemastore.conformers :as sc :refer [uuid timestamp?]]))
 
-(defn timestamp
-  []
-  (tf/unparse
-   (tf/formatters :basic-date-time)
-   (t/now)))
-
-(defn timestamp?
-  [s]
-  (tf/parse
-   (tf/formatters :basic-date-time)
-   s))
-
-(defn uuid?
-  [s]
-  (re-find #"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
-           s))
-
-(s/def ::id uuid?)
+(s/def ::id uuid)
 (s/def ::tag keyword?)
 (s/def ::timestamp timestamp?)
 (s/def ::name #(and (keyword? %)

--- a/src/kixi/datastore/schemastore/conformers.clj
+++ b/src/kixi/datastore/schemastore/conformers.clj
@@ -1,6 +1,9 @@
 (ns kixi.datastore.schemastore.conformers
   (:require [clojure.core :exclude [integer? double? set?]]
-            [clojure.spec :as s]))
+            [clojure.spec :as s]
+            [clojure.spec.gen :as gen]
+            [clj-time.core :as t]
+            [clj-time.format :as tf]))
 
 (defn double->int
   "1.0 will convert to 1; anything else will be rejected"
@@ -141,10 +144,26 @@
     (string? x) (Boolean/valueOf (str x))
     :else :clojure.spec/invalid))
 
-(def bool? (s/conformer -bool?))
+(def bool? (s/with-gen (s/conformer -bool?)
+             (constantly (gen/boolean))))
 
 (defn -string?
   [x]
   (cond
     (string? x) x
     :else (str x)))
+
+(defn timestamp?
+  [s]
+  (tf/parse
+   (tf/formatters :basic-date-time)
+   s))
+
+(def uuid?
+  (partial re-find #"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"))
+
+(def uuid (s/with-gen uuid?
+            #(gen/fmap str (gen/uuid))))
+
+(def anything (s/with-gen (constantly true)
+                #(gen/any)))

--- a/src/kixi/datastore/schemastore/inmemory.clj
+++ b/src/kixi/datastore/schemastore/inmemory.clj
@@ -7,12 +7,13 @@
             [kixi.datastore.schemastore.conformers :as conformers]
             [kixi.comms :as c]
             [kixi.datastore.transit :as t]
+            [kixi.datastore.time :as time]
             [taoensso.timbre :as timbre :refer [error info infof debug]]))
 
 (defn persist-new-schema
   [data schema]
   (let [id (::ss/id schema)
-        schema' (assoc schema ::ss/timestamp (ss/timestamp))]
+        schema' (assoc schema ::ss/timestamp (time/timestamp))]
     (if (s/valid? ::ss/stored-schema schema')
       (swap! data (fn [d] (assoc d id schema')))
       (error "Tried to persist schema but it was invalid:" schema' (s/explain-data ::ss/stored-schema schema'))))) ;should be at the command level

--- a/src/kixi/datastore/segmentation.clj
+++ b/src/kixi/datastore/segmentation.clj
@@ -1,13 +1,14 @@
 (ns kixi.datastore.segmentation
-  (:require [clojure.spec :as s]))
+  (:require [clojure.spec :as s]
+            [kixi.datastore.schemastore.conformers :refer [uuid anything]]))
 
-(s/def ::id string?)
+(s/def ::id uuid)
 (s/def ::column-name string?)
 (s/def ::line-count int?)
-(s/def ::value (constantly true))
+(s/def ::value anything)
 (s/def ::created boolean?)
 (s/def ::reason #{:unknown-file-type :file-not-found :invalid-column})
-(s/def ::cause (constantly true))
+(s/def ::cause anything)
 (s/def ::type #{::group-rows-by-column})
 
 (s/def ::error

--- a/src/kixi/datastore/time.clj
+++ b/src/kixi/datastore/time.clj
@@ -1,0 +1,9 @@
+(ns kixi.datastore.time
+  (:require [clj-time.core :as t]
+            [clj-time.format :as tf]))
+
+(defn timestamp
+  []
+  (tf/unparse
+   (tf/formatters :basic-date-time)
+   (t/now)))

--- a/src/kixi/datastore/transport_specs.clj
+++ b/src/kixi/datastore/transport_specs.clj
@@ -1,0 +1,45 @@
+(ns kixi.datastore.transport-specs
+  (:require [clojure.spec :as s]
+            [kixi.datastore.schemastore :as ss]
+            [kixi.datastore.metadatastore :as ms]
+            [kixi.datastore.schemastore.conformers :refer [uuid]]))
+
+(s/def ::schema-id uuid)
+
+(s/def ::filemetadata-transport
+  (s/keys :req-un [::schema-id
+                   ::ms/name
+                   ::ms/header]
+          :opt-un [::ms/type]))
+
+(s/def ::file-details
+  (s/keys :req [::ms/id ::ms/size-bytes ::ms/provenance]))
+
+(def file-type->default-metadata
+  {"csv" {::ms/headers true}})
+
+(def default-primary-metadata
+  {::ms/type "csv"})
+
+(s/fdef filemetadata-transport->internal
+        :args (s/cat :meta ::filemetadata-transport
+                     :details ::file-details)
+        :ret ::ms/file-metadata)
+
+(def key-mapping
+  {:name ::ms/name
+   :header ::ms/header
+   :type ::ms/type
+   :schema-id ::ss/id})
+
+(defn filemetadata-transport->internal
+  [transport file-details]
+  (let [mapped (zipmap (map key-mapping (keys transport))
+                       (vals transport))
+        with-primaries (merge default-primary-metadata
+                              mapped)
+        with-file-type (merge (get file-type->default-metadata
+                                   (::ms/type with-primaries))
+                              with-primaries)]
+    (merge with-file-type
+           file-details)))

--- a/src/kixi/datastore/transport_specs.clj
+++ b/src/kixi/datastore/transport_specs.clj
@@ -8,9 +8,9 @@
 
 (s/def ::filemetadata-transport
   (s/keys :req-un [::schema-id
-                   ::ms/name
-                   ::ms/header]
-          :opt-un [::ms/type]))
+                   ::ms/name]
+          :opt-un [::ms/type
+                   ::ms/header]))
 
 (s/def ::file-details
   (s/keys :req [::ms/id ::ms/size-bytes ::ms/provenance]))

--- a/test/kixi/integration/base.clj
+++ b/test/kixi/integration/base.clj
@@ -78,6 +78,10 @@
     (json/parse-string s keyword)
     s))
 
+(defn encode-json
+  [m]
+  (json/encode m))
+
 (def file-url (str "http://" (service-url) "/file"))
 
 (defn metadata-url
@@ -102,10 +106,9 @@
   (check-file file-name)
   (update (client/post file-url
                        {:multipart [{:name "file" :content (io/file file-name)}
-                                    {:name "file-size-bytes" :content (str (.length (io/file file-name)))}
-                                    {:name "name" :content "foo"}
-                                    {:name "header" :content "true"}
-                                    {:name "schema-id" :content schema-id}]
+                                    {:name "file-metadata" :content (encode-json {:name "foo"
+                                                                                  :header true
+                                                                                  :schema-id schema-id})}]
                         :throw-exceptions false
                         :accept :json})
           :body parse-json))

--- a/test/kixi/unit/transport_specs_test.clj
+++ b/test/kixi/unit/transport_specs_test.clj
@@ -1,0 +1,17 @@
+(ns kixi.unit.transport-specs-test
+  (:require [clojure.test :refer :all]
+            [clojure.test.check :as tc]
+            [clojure.spec :as s]
+            [clojure.spec.test :as stest]
+            [clojure.spec.gen :as gen]
+            [environ.core :refer [env]]
+            [kixi.datastore.metadatastore :as ms]
+            [kixi.datastore.transport-specs :as ts]))
+
+(stest/instrument `ts/filemetadata-transport->internal)
+
+(def sample-size (Integer/valueOf (str (env :generative-testing-size "1000"))))
+
+(deftest test-filemetadata-transport->internal
+  (is (nil? (:failure
+             (stest/abbrev-result (first (stest/check `ts/filemetadata-transport->internal {:num-tests sample-size})))))))


### PR DESCRIPTION
Instead of each piece of metadata being defined in a separate part of the multi-part request, there are now only two parts. One for the file, the other for a json encoded map of metadata.

The metadata must conform to the new transport-spec for incoming metadata and it's transposed into the internal format in the transport_specs namespace. Both the internal and external have been modified so that they can be generated, allowing the transposition function to be fdef'd and auto-tested by spec.check.

This allows us to have optional elements in the metadata.