### PR TITLE
Schema sharing information stored

### DIFF
--- a/src/kixi/datastore/metadatastore.clj
+++ b/src/kixi/datastore/metadatastore.clj
@@ -18,18 +18,11 @@
 
 (s/def :kixi.user-group/id sc/uuid)
 
-(def file-activities
-   [:read])
+(def activities
+  [:file-read :meta-visible :meta-read :meta-update])
 
-(def file-metadata-activities
-  [:visible :read :update])
-
-(s/def ::file-sharing
-  (s/map-of (set file-activities)
-            (s/coll-of :kixi.user-group/id)))
-
-(s/def ::file-metadata-sharing
-  (s/map-of (set file-metadata-activities)
+(s/def ::sharing
+  (s/map-of (set activities)
             (s/coll-of :kixi.user-group/id)))
 
 (s/def :kixi.datastore.request/type #{::seg/group-rows-by-column})
@@ -82,7 +75,7 @@
           :opt [::explain]))
 
 (s/def ::file-metadata
-  (s/keys :req [::type ::id ::name ::schemastore/id ::provenance ::size-bytes ::file-sharing ::file-metadata-sharing]
+  (s/keys :req [::type ::id ::name ::schemastore/id ::provenance ::size-bytes ::sharing]
           :opt [::segmentations ::segment ::structural-validation]))
 
 (defprotocol MetaDataStore

--- a/src/kixi/datastore/schemastore.clj
+++ b/src/kixi/datastore/schemastore.clj
@@ -8,6 +8,13 @@
 (s/def ::name #(and (keyword? %)
                     (namespace %)))
 
+(def activities
+  [::read ::use])
+
+(s/def ::sharing
+  (s/map-of (set activities)
+            (s/coll-of :kixi.user-group/id)))
+
 (s/def ::definition
   (s/cat :pairs (s/+ (s/cat :tag ::tag
                             :type ::schema))))
@@ -48,10 +55,10 @@
   (s/multi-spec schema-type ::type))
 
 (s/def ::stored-schema
-  (s/keys :req [::schema ::id ::name ::timestamp]))
+  (s/keys :req [::schema ::id ::name ::timestamp ::sharing]))
 
 (s/def ::create-schema-request
-  (s/keys :req [::schema ::id ::name]))
+  (s/keys :req [::schema ::id ::name ::sharing]))
 
 (defprotocol SchemaStore
   (exists [this spec-name])

--- a/src/kixi/datastore/schemastore.clj
+++ b/src/kixi/datastore/schemastore.clj
@@ -27,7 +27,7 @@
 
 (s/def ::definition
   (s/cat :pairs (s/+ (s/cat :tag ::tag
-                            :type ::primative-schema))))
+                            :type ::primitive-schema))))
 
 (s/def ::list-spec
   (s/keys :req [::type ::definition]))
@@ -61,13 +61,13 @@
 (defmethod schema-type "string" [_]
   (s/keys :req [::type]))
 
-(s/def ::primative-schema 
+(s/def ::primitive-schema 
   (s/multi-spec schema-type ::type))
 
 (s/def ::schema
   (s/or
    :list ::list-spec
-   :primative ::primative-schema))
+   :primitive ::primitive-schema))
 
 (s/def ::type (set (conj (keys (methods schema-type))
                          "list")))

--- a/src/kixi/datastore/schemastore.clj
+++ b/src/kixi/datastore/schemastore.clj
@@ -8,11 +8,11 @@
 (s/def ::tag keyword?)
 (s/def ::timestamp timestamp)
 (s/def ::name ns-keyword)
-(s/def ::min integer?)
-(s/def ::max integer?)
+(s/def ::min number?)
+(s/def ::max number?)
 (s/def ::pattern string?)
-(s/def ::elements (s/with-gen set?
-                    #(gen/set (gen/string)
+(s/def ::elements (s/with-gen vector?
+                    #(gen/vector (gen/string)
                               {:min-elements 1
                                :max-elements 10})))
 

--- a/src/kixi/datastore/schemastore/inmemory.clj
+++ b/src/kixi/datastore/schemastore/inmemory.clj
@@ -8,7 +8,7 @@
             [kixi.comms :as c]
             [kixi.datastore.transit :as t]
             [kixi.datastore.time :as time]
-            [taoensso.timbre :as timbre :refer [error info infof debug]]))
+            [taoensso.timbre :as timbre :refer [error info infof debug fatal]]))
 
 (defn persist-new-schema
   [data schema]

--- a/src/kixi/datastore/segmentation/inmemory.clj
+++ b/src/kixi/datastore/segmentation/inmemory.clj
@@ -96,8 +96,7 @@
                                         ::ms/name
                                         ::ss/id
                                         ::ms/header
-                                        ::ms/file-sharing
-                                        ::ms/file-metadata-sharing])
+                                        ::ms/sharing])
                           ::ms/id (:id segment-data)
                           ::ms/size-bytes (:size-bytes segment-data)
                           ::ms/provenance {::ms/source "segmentation"
@@ -169,6 +168,9 @@
                 ::seg/segment-ids result})
              (hash-map ::cs/file-metadata-update-type ::cs/file-metadata-segmentation-add ::ms/id (::ms/id request) ::ms/segmentation)
              (hash-map :kixi.comms.event/key :kixi.datastore/file-metadata-updated :kixi.comms.event/version "1.0.0" :kixi.comms.event/payload))))))
+
+(comment "There is something horrible happening when target file has invalid metadata, seems to end up with the entire consumer config in the payload.
+Not a problem for now, but when productionising this code, investigate!")
 
 (defrecord InMemory
     [communications filestore metadatastore]

--- a/src/kixi/datastore/sharing.clj
+++ b/src/kixi/datastore/sharing.clj
@@ -7,7 +7,7 @@
     [domain action]))
 
 (defmethod authorisation
-  [::ms/file-sharing :read]  
+  [::ms/sharing :file-read]  
   [file-metadatastore domain action id groups]
   (ms/authorisation file-metadatastore
                     domain
@@ -16,7 +16,7 @@
                     groups))
 
 (defmethod authorisation
-  [::ms/file-metadata-sharing :read]  
+  [::ms/sharing :meta-read]  
   [file-metadatastore domain action id groups]
   (ms/authorisation file-metadatastore
                     domain

--- a/src/kixi/datastore/transport_specs.clj
+++ b/src/kixi/datastore/transport_specs.clj
@@ -11,8 +11,7 @@
                    ::ms/name]
           :opt-un [::ms/type
                    ::ms/header
-                   ::ms/file-sharing
-                   ::ms/file-metadata-sharing]))
+                   ::ms/sharing]))
 
 (s/def ::file-details
   (s/keys :req [::ms/id ::ms/size-bytes ::ms/provenance]))
@@ -22,8 +21,7 @@
 
 (def default-primary-metadata
   {::ms/type "csv"
-   ::ms/file-sharing {}
-   ::ms/file-metadata-sharing {}})
+   ::ms/sharing {}})
 
 (s/fdef filemetadata-transport->internal
         :args (s/cat :meta ::filemetadata-transport
@@ -40,14 +38,10 @@
                        (::ss/id file-metadata))
                     (= (:name meta)
                        (::ms/name file-metadata))
-                    (or (= (:file-sharing meta)
-                           (::ms/file-sharing file-metadata))
+                    (or (= (:sharing meta)
+                           (::ms/sharing file-metadata))
                         (= {}
-                           (::ms/file-sharing file-metadata)))
-                    (or (= (:file-metadata-sharing meta)
-                           (::ms/file-metadata-sharing file-metadata))
-                        (= {}
-                           (::ms/file-metadata-sharing file-metadata)))
+                           (::ms/sharing file-metadata)))
                     (case (or (:type meta) 
                               (::ms/type file-metadata)) 
                       "csv" (if-not (nil? (:header meta))
@@ -62,8 +56,7 @@
    :header ::ms/header
    :type ::ms/type
    :schema-id ::ss/id
-   :file-sharing ::ms/file-sharing
-   :file-metadata-sharing ::ms/file-metadata-sharing})
+   :sharing ::ms/sharing})
 
 (defn filemetadata-transport->internal
   [transport file-details]

--- a/src/kixi/datastore/transport_specs.clj
+++ b/src/kixi/datastore/transport_specs.clj
@@ -103,15 +103,14 @@
                           % 2))
       m')))
 
-(s/fdef schema-transport->internal
-        :args (s/cat :transport ::schema-transport)
+(s/fdef schema-transport->internal      
         :ret ::ss/create-schema-request)
 
 (defn schema-transport->internal
   [transport]
- ; (prn transport)
-  (let [schema transport]
-;    (prn schema)
+  (let [schema (keywordize-values
+                (add-ns-to-keys ::ss/_ 
+                                   transport))]
     schema))
 
 (defn raise-spec

--- a/src/kixi/datastore/web_server.clj
+++ b/src/kixi/datastore/web_server.clj
@@ -267,7 +267,7 @@
            :response
            (fn [ctx]
              (let [id (get-in ctx [:parameters :path :id])]
-               (if (share/authorised sharing ::ms/file-sharing :read id (ctx->user-groups ctx))
+               (if (share/authorised sharing ::ms/sharing :file-read id (ctx->user-groups ctx))
                  (ds/retrieve filestore
                               id)
                  (return-unauthorised ctx))))}}}))
@@ -282,7 +282,7 @@
            :response
            (fn [ctx]
              (let [id (get-in ctx [:parameters :path :id])]
-               (if (share/authorised sharing ::ms/file-metadata-sharing :read id (ctx->user-groups ctx))
+               (if (share/authorised sharing ::ms/sharing :meta-read id (ctx->user-groups ctx))
                  (ms/fetch metadatastore id)
                  (return-unauthorised ctx))))}}}))
 
@@ -385,7 +385,7 @@
                               body        (get-in ctx [:body])
                               schema      (keywordize-values
                                            (add-ns-to-keys ::ss/_ (:schema body)))                              
-                              schema'     (dissoc schema ::ss/name)
+                              schema'     (dissoc schema ::ss/name ::ss/sharing)
                               schema-name (::ss/name schema)]
                           ;; Is name valid?
                           (if-let [error (sv/invalid-name? schema-name)]
@@ -410,7 +410,8 @@
                                                    ::cs/version "1.0.0"
                                                    ::ss/name schema-name
                                                    ::ss/schema schema'
-                                                   ::ss/id new-id})
+                                                   ::ss/id new-id
+                                                   ::ss/sharing (get schema ::ss/sharing)})
                                   (assoc (:response ctx)
                                          :status 202
                                          :headers {"Location"

--- a/test/kixi/integration/metadata_test.clj
+++ b/test/kixi/integration/metadata_test.clj
@@ -13,9 +13,9 @@
 
 (def metadata-file-schema-id (atom nil))
 (def metadata-file-schema {:name ::metadata-file-schema
-                           :type "list"
-                           :definition [:cola {:type "integer"}
-                                        :colb {:type "integer"}]})
+                           :schema {:type "list"
+                                    :definition [:cola {:type "integer"}
+                                                 :colb {:type "integer"}]}})
 
 (def uid (uuid))
 
@@ -31,8 +31,7 @@
 
 (deftest unknown-file-401
   (let [sr (get-metadata "foo" uid)]
-    (is (= 401
-           (:status sr)))))
+    (unauthorised sr)))
 
 (deftest small-file
   (let [pfr (post-file "./test-resources/metadata-one-valid.csv"

--- a/test/kixi/integration/sharing_test.clj
+++ b/test/kixi/integration/sharing_test.clj
@@ -5,9 +5,9 @@
             [kixi.integration.base :refer [uuid extract-id when-accepted when-created] :as base]))
 
 (def metadata-file-schema {:name ::metadata-file-schema
-                           :type "list"
-                           :definition [:cola {:type "integer"}
-                                        :colb {:type "integer"}]})
+                           :schema {:type "list"
+                                    :definition [:cola {:type "integer"}
+                                                 :colb {:type "integer"}]}})
 
 (use-fixtures :once base/cycle-system-fixture)
 
@@ -34,8 +34,9 @@
    [[:sharing :meta-visible]] []
    [[:sharing :meta-read]] [get-metadata]
    [[:sharing :meta-update]] []
-   [[:sharing :read]] []
-   [[:sharing :use]] []})
+   ;[[:sharing :read]] []
+   ;[[:sharing :use]] []
+   })
 
 (def all-shares 
   (vec (reduce (partial apply conj) #{} (keys shares->authorised-actions))))
@@ -77,7 +78,7 @@
                 pfr (apply post-file
                            :schema-id schema-id
                            :user-id upload-uid
-                           :user-group upload-ugroup
+                           :user-groups upload-ugroup
                            (shares->file-shares upload-ugroup shares use-ugroup))]
             (when-created pfr
               (let [file-id (extract-id pfr)

--- a/test/kixi/integration/sharing_test.clj
+++ b/test/kixi/integration/sharing_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer :all]
             [clojure.math.combinatorics :as combo :refer [subsets]]
             [environ.core :refer [env]]
-            [kixi.integration.base :refer [uuid extract-id] :as base]))
+            [kixi.integration.base :refer [uuid extract-id when-accepted when-created] :as base]))
 
 (def metadata-file-schema {:name ::metadata-file-schema
                            :type "list"
@@ -30,11 +30,12 @@
   (base/get-metadata file-id ugroups))
 
 (def shares->authorised-actions
-  {[[:file-sharing :read]] [get-file]
-   [[:file-metadata-sharing :visible]] []
-   [[:file-metadata-sharing :read]] [get-metadata]
-   [[:file-metadata-sharing :update]] []
-   })
+  {[[:sharing :file-read]] [get-file]
+   [[:sharing :meta-visible]] []
+   [[:sharing :meta-read]] [get-metadata]
+   [[:sharing :meta-update]] []
+   [[:sharing :read]] []
+   [[:sharing :use]] []})
 
 (def all-shares 
   (vec (reduce (partial apply conj) #{} (keys shares->authorised-actions))))
@@ -56,38 +57,21 @@
           (merge-with (partial merge-with concat)
                       acc
                       {share-area {share-specific [dload-ugroup]}}))
-        {:file-sharing {:read [ugroup]}
-         :file-metadata-sharing {:read [ugroup]}})
+        {:sharing {:file-read [ugroup]
+                   :meta-read [ugroup]}})
        seq
        flatten))
-
-(defmacro when-status
-  [status resp rest]
-  `(let [rs# (:status ~resp)]
-     (base/is-submap {:status ~status}
-                ~resp)
-     (when (= ~status
-              rs#)
-       ~@rest)))
-
-(defmacro when-accepted
-  [resp & rest]
-  `(when-status 202 ~resp ~rest))
-
-(defmacro when-created
-  [resp & rest]
-  `(when-status 201 ~resp ~rest))
 
 (deftest explore-sharing-level->actions
   (let [post-file (partial base/post-file-and-wait
                            :file-name "./test-resources/metadata-one-valid.csv")
-        post-spec #(base/post-spec-and-wait metadata-file-schema (uuid))] ;will become partial with spec perms
+        post-spec (partial base/post-spec-and-wait metadata-file-schema)]
     (doseq [shares (subsets all-shares)]
       (let [upload-uid (uuid)
             upload-ugroup (uuid)
             use-uid (uuid)
             use-ugroup (uuid)
-            psr (post-spec)]
+            psr (post-spec upload-uid upload-ugroup)]
         (when-accepted psr
           (let [schema-id (extract-id psr)
                 pfr (apply post-file

--- a/test/kixi/integration/spec_test.clj
+++ b/test/kixi/integration/spec_test.clj
@@ -2,13 +2,13 @@
   (:require [clojure.test :refer :all]
             [clojure.spec :as s]
             [clj-http.client :as client]
-            [kixi.datastore.web-server :refer [add-ns-to-keys]]
+            [kixi.datastore.transport-specs :refer [add-ns-to-keys]]
             [kixi.datastore.schemastore :as ss]
             [kixi.datastore.schemastore.conformers :as conformers]
             [kixi.integration.base :refer [service-url cycle-system-fixture uuid
                                            post-spec get-spec extract-schema parse-json
                                            wait-for-url is-submap extract-id
-                                           get-spec-direct]]))
+                                           get-spec-direct when-accepted post-spec-and-wait]]))
 
 (def uuid-regex
   #"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
@@ -22,12 +22,11 @@
 
 (deftest good-round-trip
   (let [schema {:name ::new-good-spec-a
-                :type "integer-range"
-                :min 3
-                :max 10}
-        r1 (post-spec schema)]
-    (is-submap {:status 202} r1)
-    (if (= 202 (:status r1))
+                :schema {:type "integer-range"
+                         :min 3
+                         :max 10}}
+        r1 (post-spec schema uid)]
+    (when-accepted r1
       (let [location (get-in r1 [:headers "Location"])
             id       (extract-id r1)
             r2       (get-spec id uid)]
@@ -35,7 +34,7 @@
         (is (re-find uuid-regex id))
         (is-submap {:status 200} r2)
         (is-submap (add-ns-to-keys ::ss/_ (dissoc schema :name))
-                   (::ss/schema (extract-schema r2)))))))
+                   (extract-schema r2))))))
 
 (deftest unknown-spec-404
   (let [r-g (get-spec-direct "c0bbb46f-9a31-47c2-b30c-62eba45470d4")]
@@ -45,68 +44,65 @@
 (comment "This next test is likely to be flaky as it depends on how quickly the events are consumed. Need an idempotent schema create...")
 (deftest repost-spec-get-same-result
   (let [schema {:name ::reposted-a
-                :type "integer"}
-        r-g1 (post-spec schema)
-        _ (wait-for-url (get-in r-g1 [:headers "Location"]) uid)
-        r-g2 (post-spec schema)]
-    (is (= 202
-           (:status r-g1)))
-    (is (= 202
-           (:status r-g2)))
-    (is (= (get-in r-g1 [:headers "Location"])
-           (get-in r-g2 [:headers "Location"])))))
+                :schema {:type "integer"}}
+        r-g1 (post-spec-and-wait schema uid)
+        r-g2 (post-spec schema uid)]
+    (when-accepted r-g1
+      (when-accepted r-g2
+        (is (= (get-in r-g1 [:headers "Location"])
+               (get-in r-g2 [:headers "Location"])))))))
 
 (deftest good-spec-202
   (is (= 202 (:status (post-spec {:name ::good-spec-a
-                                  :type "integer-range"
-                                  :min 3
-                                  :max 10}))))
+                                  :schema {:type "integer-range"
+                                           :min 3
+                                           :max 10}} uid))))
   (is (= 202 (:status (post-spec {:name ::good-spec-b
-                                  :type "integer"}))))
-  (is (= 202 (:status (post-spec {:name ::good-spec-c
-                                  :type "list"
-                                  :definition [:foo {:type "integer"}
-                                               :bar {:type "integer"}
-                                               :baz {:type "integer-range"
-                                                     :min 3
-                                                     :max 10}]})))))
+                                  :schema {:type "integer"}} uid))))
+  (when-accepted (post-spec {:name ::good-spec-c
+                             :schema {:type "list"
+                                      :definition [:foo {:type "integer"}
+                                                   :bar {:type "integer"}
+                                                   :baz {:type "integer-range"
+                                                         :min 3
+                                                         :max 10}]}} uid)
+    true))
 
 (deftest good-spec-202-with-reference
   (let [schema {:name ::ref-good-spec-a
-                :type "integer-range"
-                :min 3
-                :max 10}
-        r1       (post-spec schema)]
-    (is-submap {:status 202} r1)
-    (if (= 202 (:status r1))
+                :schema {:type "integer-range"
+                         :min 3
+                         :max 10}}
+        r1       (post-spec-and-wait schema uid)]
+    (when-accepted r1      
       (let [location (get-in r1 [:headers "Location"])
             id       (extract-id r1)]
         (is (= 202 (:status (post-spec {:name ::ref-good-spec-b
-                                        :type "id"
-                                        :id    id}))))
+                                        :schema {:type "id"
+                                                 :id    id}} uid))))
         (is (= 202 (:status (post-spec {:name ::ref-good-spec-b
-                                        :type "list"
-                                        :definition [:foo {:type "id"
-                                                           :id   id}
-                                                     :bar {:type "integer"}
-                                                     :baz {:type "integer-range"
-                                                           :min 3
-                                                           :max 10}]}))))))))
+                                        :schema {:type "list"
+                                                 :definition [:foo {:type "id"
+                                                                    :id   id}
+                                                              :bar {:type "integer"}
+                                                              :baz {:type "integer-range"
+                                                                    :min 3
+                                                                    :max 10}]}} uid))))))))
 
 (deftest bad-specs
-  (is (= 400 (:status (post-spec {:type "integer"})))   "Missing args (name)")
+  (is (= 400 (:status (post-spec {:type "integer"} uid)))   "Missing args (name)")
   (is (= 400 (:status (post-spec {:name :foo
-                                  :type "integer"})))   "Unnamespaced name")
+                                  :schema {:type "integer"}} uid)))   "Unnamespaced name")
   (is (= 400 (:status (post-spec {:name ::foo
-                                  :type "foo"})))       "Unknown type")
+                                  :schema {:type "foo"}} uid)))       "Unknown type")
   (is (= 400 (:status (post-spec {:name ::foo
-                                  :type "integer-range"
-                                  :foo 1})))            "Invalid type")
+                                  :schema {:type "integer-range"
+                                           :foo 1}} uid)))            "Invalid type")
   (is (= 400 (:status (post-spec {:name ::foo
-                                  :type "list"
-                                  :definition [:foo]}))) "Invalid type")
+                                  :schema {:type "list"
+                                           :definition [:foo]}} uid))) "Invalid type")
 
   (is (= 400 (:status (post-spec {:name ::foo
-                                  :type "list"
-                                  :definition [:foo
-                                               {:type "foo"}]}))) "Invalid type"))
+                                  :schema {:type "list"
+                                           :definition [:foo
+                                                        {:type "foo"}]}} uid))) "Invalid type"))

--- a/test/kixi/integration/upload_test.clj
+++ b/test/kixi/integration/upload_test.clj
@@ -19,11 +19,10 @@
 
 (defn setup-schema
   [all-tests]
-  (let [r (post-spec irrelevant-schema)]
+  (let [r (post-spec-and-wait irrelevant-schema uid)]
     (if (= 202 (:status r))
       (reset! irrelevant-schema-id (extract-id r))
-      (throw (Exception. "Couldn't post irrelevant-schema")))
-    (wait-for-url (get-in r [:headers "Location"]) uid))
+      (throw (Exception. "Couldn't post irrelevant-schema"))))
   (all-tests))
 
 (use-fixtures :once cycle-system-fixture setup-schema)

--- a/test/kixi/integration/upload_test.clj
+++ b/test/kixi/integration/upload_test.clj
@@ -11,9 +11,9 @@
 
 (def irrelevant-schema-id (atom nil))
 (def irrelevant-schema {:name ::irrelevant-schema
-                        :type "list"
-                        :definition [:cola {:type "integer"}
-                                     :colb {:type "integer"}]})
+                        :schema {:type "list"
+                                 :definition [:cola {:type "integer"}
+                                              :colb {:type "integer"}]}})
 
 (def uid (uuid))
 

--- a/test/kixi/unit/schemastore/schemastore_test.clj
+++ b/test/kixi/unit/schemastore/schemastore_test.clj
@@ -69,7 +69,8 @@
   `(let [id#         (uuid)
          schema-req# {::ss/name ~schema-name
                       ::ss/schema ~schema-def
-                      ::ss/id id#}]
+                      ::ss/id id#
+                      ::ss/sharing {}}]
      (ssim/persist-new-schema (:data @schemastore) schema-req#)
      (is-submap schema-req# (ss/fetch-spec @schemastore id#))
      (checking "good data passes" sample-size

--- a/test/kixi/unit/transport_specs_test.clj
+++ b/test/kixi/unit/transport_specs_test.clj
@@ -6,14 +6,25 @@
             [clojure.spec.gen :as gen]
             [environ.core :refer [env]]
             [kixi.datastore.metadatastore :as ms]
-            [kixi.datastore.transport-specs :as ts]))
+            [kixi.datastore.transport-specs :as ts]
+            [kixi.datastore.schemastore :as ss]))
 
-(stest/instrument `ts/filemetadata-transport->internal)
+(stest/instrument `ts/filemetadata-transport->internal
+                  `ts/schema-transport->internal)
 
-(def sample-size (Integer/valueOf (str (env :generative-testing-size "1000"))))
+(def sample-size (Integer/valueOf (str (env :generative-testing-size "100"))))
+
+(defn check
+  [sym]
+  (-> sym
+      (stest/check {:clojure.spec.test.check/opts {:num-tests sample-size}})
+      first
+      stest/abbrev-result
+      :failure))
 
 (deftest test-filemetadata-transport->internal
-  (is (nil? (:failure
-             (stest/abbrev-result (first (stest/check `ts/filemetadata-transport->internal {:num-tests sample-size})))))))
+  (is (nil? (check `ts/filemetadata-transport->internal))))
 
 
+(deftest test-schema-transport->internal
+  (is (nil? (check `ts/schema-transport->internal))))

--- a/test/kixi/unit/web_server_test.clj
+++ b/test/kixi/unit/web_server_test.clj
@@ -4,35 +4,3 @@
             [kixi.datastore.schemastore :as ss]
             [clojure.walk :as walk]))
 
-(deftest add-schemastore-keywords-simple
-  (let [r (add-ns-to-keys ::ss/_ {:foo 1 :bar 2 :baz 3})]
-    (is (= 1 (::ss/foo r)))
-    (is (= 2 (::ss/bar r)))
-    (is (= 3 (::ss/baz r)))))
-
-(deftest add-schemastore-keywords-nested
-  (let [r (add-ns-to-keys ::ss/_ {:foo 1 :bar {:baz 2}})]
-    (is (= 1 (::ss/foo r)))
-    (is (= 2 (get-in r [::ss/bar ::ss/baz])))))
-
-(deftest add-schemastore-keywords-nestedx2
-  (let [r (add-ns-to-keys ::ss/_ {:foo 1 :bar {:baz {:quaz 2}}})]
-    (is (= 1 (::ss/foo r)))
-    (is (= 2 (get-in r [::ss/bar ::ss/baz ::ss/quaz])))))
-
-(deftest add-schemastore-keywords-not-vectors
-  (let [r (add-ns-to-keys ::ss/_ {:foo 1 :bar [:a 1 :b 2]})]
-    (is (= 1 (::ss/foo r)))
-    (is (= [:a 1 :b 2] (::ss/bar r)))))
-
-(deftest add-schemastore-epic-test
-  (let [r (add-ns-to-keys ::ss/_ {:name ::good-spec-c
-                                      :type "list"
-                                      :definition [:foo {:type "integer"}
-                                                   :bar {:type "integer"}
-                                                   :baz {:type "integer-range"
-                                                         :min 3
-                                                         :max 10}]})]
-    (is (= "list" (::ss/type r)))
-    (is (= :bar (get-in r [::ss/definition 2])))
-    (is (= 10 (get-in r [::ss/definition 5 ::ss/max])))))


### PR DESCRIPTION
The ground layer for schema permissions. These changes allow the :sharing information to be stored within the metadata for the schema.

This involved quite a bit of faffing around:

 The schema definitions have been nested with the schema data, instead of being top level.
 The file sharing has been consolidated, so that :sharing is a common tag across both entities.
 Our internal timestamp schema type has been fixed.
 Schemas can now be generated.
 List's and primitive schemas have been separated, so you can not have list of list schemas.
 Namespaced keyword schema type created.
 The schema transform util functions have been moved into the transport-spec namespace.
 The whole schema upload section has been refactored.
 Lots of little testing functions created and refactored to try and keep the tests readable and uniformly informative when failing.