### PR TITLE
ElasticSearch for metadata storage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ influxdb:
           - "8086:8086"
           - "8083:8083"
 elasticsearch:
-        image: 'elasticsearch:5.0.0'
+        image: 'elasticsearch:2.4.1'
         ports:
           - "9200:9200"
           - "9300:9300"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,4 +17,9 @@ influxdb:
         ports:
           - "8086:8086"
           - "8083:8083"
+elasticsearch:
+        image: 'elasticsearch:5.0.0'
+        ports:
+          - "9200:9200"
+          - "9300:9300"
         

--- a/project.clj
+++ b/project.clj
@@ -7,22 +7,30 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[aero "1.0.0"]
                  [aleph "0.4.2-alpha8"]
-                 [amazonica "0.3.74" :exclusions [com.fasterxml.jackson.dataformat/jackson-dataformat-cbor
+                 [amazonica "0.3.74" :exclusions [ch.qos.logback/logback-classic
+                                                  com.fasterxml.jackson.dataformat/jackson-dataformat-cbor
                                                   commons-logging
-                                                  com.fasterxml.jackson.core/jackson-core]]
+                                                  com.fasterxml.jackson.core/jackson-databind
+                                                  com.fasterxml.jackson.core/jackson-core
+                                                  org.apache.httpcomponents/httpclient
+                                                  joda-time]]
                  [bidi "2.0.9"]
                  [byte-streams "0.2.2"]
                  [clj-http "2.2.0"]
                  [clj-time "0.12.0"]
                  [clojure-csv/clojure-csv "2.0.1"]
+                 [cheshire "5.6.3"]
                  [com.cognitect/transit-clj "0.8.288"]
-                 [com.izettle/dropwizard-metrics-influxdb "1.1.6" :exclusions [ch.qos.logback/logback-classic]]
+                 [com.izettle/dropwizard-metrics-influxdb "1.1.6" :exclusions [ch.qos.logback/logback-classic 
+                                                                               com.fasterxml.jackson.core/jackson-core
+                                                                               joda-time]]
                  [com.fzakaria/slf4j-timbre "0.3.2"]
                  [com.stuartsierra/component "0.3.1"]
                  [com.taoensso/timbre "4.7.0"]
                  [digest "1.4.4"]
+                 [clojurewerkz/elastisch "3.0.0-beta1"]
                  [environ "1.1.0"]
-                 [kixi/kixi.comms "0.1.8" :exclusions [cheshire]]
+                 [kixi/kixi.comms "0.1.8"]
                  [manifold "0.1.6-alpha1"]
                  [medley "0.8.3"]
                  [metrics-clojure ~metrics-version]
@@ -35,7 +43,9 @@
                  [org.slf4j/log4j-over-slf4j ~slf4j-version]
                  [org.slf4j/jul-to-slf4j ~slf4j-version]
                  [org.slf4j/jcl-over-slf4j ~slf4j-version]
-                 [yada "1.1.33"]]
+                 [yada "1.1.33" :exclusions [com.fasterxml.jackson.core/jackson-core]]]
+
+  :exclusions [cheshire]
 
   :test-selectors {:default (complement :integration)
                    :integration :integration}

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -28,9 +28,8 @@
            ;;:ns-whitelist  ["whiner.*"] #_["my-app.foo-ns"]
            :ns-blacklist ["org.eclipse.jetty"]}
  :filestore {:local {:base-dir "/kixi-datastore"}}
- :metadatastore {:inmemory {}
-                 :elasticsearch {:host {:local "localhost"}
-                                 :post 9300}}
+ :metadatastore {:elasticsearch {:host #profile {:local "localhost"}
+                                 :port 9200}}
  :schemastore {:inmemory {}}
  :segmentation {:inmemory {}}
  :communications {:kafka #profile {:local {:host "127.0.0.1"

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -28,7 +28,9 @@
            ;;:ns-whitelist  ["whiner.*"] #_["my-app.foo-ns"]
            :ns-blacklist ["org.eclipse.jetty"]}
  :filestore {:local {:base-dir "/kixi-datastore"}}
- :metadatastore {:inmemory {}}
+ :metadatastore {:inmemory {}
+                 :elasticsearch {:host {:local "localhost"}
+                                 :post 9300}}
  :schemastore {:inmemory {}}
  :segmentation {:inmemory {}}
  :communications {:kafka #profile {:local {:host "127.0.0.1"

--- a/src/kixi/datastore/metadatastore/elasticsearch.clj
+++ b/src/kixi/datastore/metadatastore/elasticsearch.clj
@@ -1,89 +1,189 @@
 (ns kixi.datastore.metadatastore.elasticsearch
   (:require [clojurewerkz.elastisch.rest :as esr]
+            [clojurewerkz.elastisch.rest.index :as esi]
+            [clojurewerkz.elastisch.rest.document :as esd]
             [clojure.spec :as s]
             [com.stuartsierra.component :as component]
             [kixi.datastore.metadatastore
              :refer [MetaDataStore] :as ms]
             [kixi.comms :as c]
             [kixi.datastore.communication-specs :as cs]
-            [taoensso.timbre :as timbre :refer [error info infof]]))
+            [kixi.datastore.schemastore :as ss]
+            [kixi.datastore.segmentation :as seg]
+            [taoensso.timbre :as timbre :refer [error info infof]]
+            [kixi.datastore.schemastore :as ss]
+            [medley.core :refer [map-keys]]))
+
+(def index-name "kixi-datastore_file-metadata")
+(def doc-type "file-metadata")
+
+(def put-opts {:consistency "default"})
+
+(defn kw->es-format
+  [kw]
+  (if (namespace kw)
+    (str (clojure.string/replace (namespace kw) "." "_")
+         "__"
+         (name kw))
+    (name kw)))
+
+(defn es-format->kw
+  [confused-kw]  
+  (let [splits (clojure.string/split (name confused-kw) #"__")]
+    (if (second splits)
+      (keyword
+       (clojure.string/replace (first splits) "_" ".")
+       (second splits))
+      confused-kw)))
+
+(defn map-all-keys
+  [f]
+  (fn mapper [m]
+    (zipmap (map f (keys m))
+            (map (fn [v]
+                   (if (map? v)
+                     (mapper v)
+                     v))
+                 (vals m)))))
+
+(def all-keys->es-format
+  (map-all-keys kw->es-format))
+
+(def all-keys->kw
+  (map-all-keys es-format->kw))
+
+(def string-stored-not_analyzed
+  {:type "string" 
+   :store "yes"
+   :index "not_analyzed"})
+
+(defn build-index
+  [conn]
+  (let [mapping-types {doc-type {:properties 
+                                 (all-keys->es-format
+                                  {::ms/id string-stored-not_analyzed
+                                   ::ms/type string-stored-not_analyzed
+                                   ::ms/name {:type "string"
+                                              :store "yes"}
+                                   ::ss/id string-stored-not_analyzed
+                                   ::ms/provenance {:type "nested"
+                                                    :properties {::ms/source string-stored-not_analyzed
+                                                                 :kixi.user/id string-stored-not_analyzed
+                                                                 ::ms/pieces-count {:type "integer"}
+                                                                 ::ms/parent-id string-stored-not_analyzed}}
+                                   ::ms/segmentation {:type "nested"
+                                                      :properties {::seg/type string-stored-not_analyzed
+                                                                   ::seg/line-count {:type "integer"}
+                                                                   ::seg/value string-stored-not_analyzed}}
+                                   ::ms/sharing {:type "nested"
+                                                 :properties (zipmap ms/activities
+                                                                     (repeat string-stored-not_analyzed))}})}}]
+    (esi/create conn index-name {:mappings mapping-types
+                                 :settings {}})))
+
+(defn ensure-index
+  [conn]
+  (when-not (esi/exists? conn index-name)
+    (build-index conn)))
+
+(defn- get-document
+  [conn id]
+  (esd/get conn
+           index-name 
+           doc-type 
+           id
+           :preference "_primary"))
 
 (s/fdef update-metadata-processor
-        :args (s/cat :data #(instance? clojure.lang.IAtom %)
+        :args (s/cat :conn #(instance? clojurewerkz.elastisch.rest.Connection %)
                      :update-req ::cs/file-metadata-updated))
 
 (defmulti update-metadata-processor
-  (fn [data update-event]
+  (fn [conn update-event]
     (::cs/file-metadata-update-type update-event)))
 
+(def apply-attempts 10)
+
+(defn- apply-func
+  ([conn id f]
+   (apply-func conn id f apply-attempts))
+  ([conn id f tries]
+   (if (pos? tries)
+     (let [curr (get-document id)]
+       (prn "PUTTED: "(esd/put conn
+                     index-name
+                     doc-type
+                     id
+                     (f (:_source curr)) 
+                     (assoc put-opts
+                            :version (:version curr)))))
+     (error "Unable to apply update in ES to document ")
+     )))
+
 (defmethod update-metadata-processor ::cs/file-metadata-created
-  [data update-event]
+  [conn update-event]
   (let [metadata (::ms/file-metadata update-event)]
     (info "Update: " metadata)
-    (swap! data
-           #(update % (::ms/id metadata)
-                    (fn [current-metadata]
-                      (merge current-metadata
-                             metadata))))))
+    ))
 
 
 (defmethod update-metadata-processor ::cs/file-metadata-structural-validation-checked
-  [data update-event]
+  [conn update-event]
   (info "Update: " update-event)
-  (swap! data
-         #(update % (::ms/id update-event)
-                  (fn [current-metadata]
-                    (assoc (or current-metadata {})
-                           ::ms/structural-validation (::ms/structural-validation update-event))))))
+  
+  #_(update % (::ms/id update-event)
+          (fn [current-metadata]
+            (assoc (or current-metadata {})
+                   ::ms/structural-validation (::ms/structural-validation update-event)))))
 
 (defmethod update-metadata-processor ::cs/file-metadata-segmentation-add
-  [data update-event]
+  [conn update-event]
   (info "Update: " update-event)
-  (swap! data
-         #(update % (::ms/id update-event)
-                  (fn [current-metadata]
-                    (update (or current-metadata {})
-                            ::ms/segmentations (fn [segs] 
-                                                 (cons (::ms/segmentation update-event) segs)))))))
+  #_(update % (::ms/id update-event)
+          (fn [current-metadata]
+            (update (or current-metadata {})
+                    ::ms/segmentations (fn [segs] 
+                                         (cons (::ms/segmentation update-event) segs))))))
 
 
 (defn response-event
   [r]
   nil)
 
-(defrecord InMemory
-    [data communications]
+(defrecord ElasticSearch
+    [communications host port conn]
     MetaDataStore
     (authorised
       [this action id user-groups]
-      (when-let [meta (get @data id)]
+      (when-let [meta (all-keys->kw (:_source (get-document conn id)))]
         (not-empty (clojure.set/intersection (set (get-in meta [::ms/sharing action]))
                                              (set user-groups)))))
     (exists [this id]
-      ((set
-        (keys @data))
-       id))
-    (fetch [this id]
-      (get @data id))
+      (esd/present? conn index-name doc-type id))
+    (fetch [this id]      
+      (all-keys->kw
+       (:_source
+        (get-document conn id))))
     (query [this criteria])
 
     component/Lifecycle
     (start [component]
-      (if-not data
-        (let [new-data (atom {})]
-          (info "Starting InMemory Metadata Store")
+      (if-not conn
+        (let [connection (esr/connect (str "http://" host ":" port)
+                                      {:connection-manager (clj-http.conn-mgr/make-reusable-conn-manager {:timeout 10})})]
+          (info "Starting ElasticSearch Metadata Store")
+          (ensure-index connection)
           (c/attach-event-handler! communications
                                    :kixi.datastore/metadatastore
                                    :kixi.datastore/file-metadata-updated
                                    "1.0.0"
-                                   (comp response-event (partial update-metadata-processor new-data) :kixi.comms.event/payload))      
-          (assoc component :data new-data))
+                                   (comp response-event (partial update-metadata-processor connection) :kixi.comms.event/payload))      
+          (assoc component :conn connection))
         component))
     (stop [component]
-      (if data
-        (do (info "Destroying InMemory Metadata Store")
-            (reset! data {})
-            (dissoc component :data))
+      (if conn
+        (do (info "Destroying ElasticSearch Metadata Store")
+            (dissoc component :conn))
         component)))
 
 

--- a/src/kixi/datastore/metadatastore/elasticsearch.clj
+++ b/src/kixi/datastore/metadatastore/elasticsearch.clj
@@ -1,0 +1,89 @@
+(ns kixi.datastore.metadatastore.elasticsearch
+  (:require [clojurewerkz.elastisch.rest :as esr]
+            [clojure.spec :as s]
+            [com.stuartsierra.component :as component]
+            [kixi.datastore.metadatastore
+             :refer [MetaDataStore] :as ms]
+            [kixi.comms :as c]
+            [kixi.datastore.communication-specs :as cs]
+            [taoensso.timbre :as timbre :refer [error info infof]]))
+
+(s/fdef update-metadata-processor
+        :args (s/cat :data #(instance? clojure.lang.IAtom %)
+                     :update-req ::cs/file-metadata-updated))
+
+(defmulti update-metadata-processor
+  (fn [data update-event]
+    (::cs/file-metadata-update-type update-event)))
+
+(defmethod update-metadata-processor ::cs/file-metadata-created
+  [data update-event]
+  (let [metadata (::ms/file-metadata update-event)]
+    (info "Update: " metadata)
+    (swap! data
+           #(update % (::ms/id metadata)
+                    (fn [current-metadata]
+                      (merge current-metadata
+                             metadata))))))
+
+
+(defmethod update-metadata-processor ::cs/file-metadata-structural-validation-checked
+  [data update-event]
+  (info "Update: " update-event)
+  (swap! data
+         #(update % (::ms/id update-event)
+                  (fn [current-metadata]
+                    (assoc (or current-metadata {})
+                           ::ms/structural-validation (::ms/structural-validation update-event))))))
+
+(defmethod update-metadata-processor ::cs/file-metadata-segmentation-add
+  [data update-event]
+  (info "Update: " update-event)
+  (swap! data
+         #(update % (::ms/id update-event)
+                  (fn [current-metadata]
+                    (update (or current-metadata {})
+                            ::ms/segmentations (fn [segs] 
+                                                 (cons (::ms/segmentation update-event) segs)))))))
+
+
+(defn response-event
+  [r]
+  nil)
+
+(defrecord InMemory
+    [data communications]
+    MetaDataStore
+    (authorised
+      [this action id user-groups]
+      (when-let [meta (get @data id)]
+        (not-empty (clojure.set/intersection (set (get-in meta [::ms/sharing action]))
+                                             (set user-groups)))))
+    (exists [this id]
+      ((set
+        (keys @data))
+       id))
+    (fetch [this id]
+      (get @data id))
+    (query [this criteria])
+
+    component/Lifecycle
+    (start [component]
+      (if-not data
+        (let [new-data (atom {})]
+          (info "Starting InMemory Metadata Store")
+          (c/attach-event-handler! communications
+                                   :kixi.datastore/metadatastore
+                                   :kixi.datastore/file-metadata-updated
+                                   "1.0.0"
+                                   (comp response-event (partial update-metadata-processor new-data) :kixi.comms.event/payload))      
+          (assoc component :data new-data))
+        component))
+    (stop [component]
+      (if data
+        (do (info "Destroying InMemory Metadata Store")
+            (reset! data {})
+            (dissoc component :data))
+        component)))
+
+

--- a/src/kixi/datastore/system.clj
+++ b/src/kixi/datastore/system.clj
@@ -20,7 +20,8 @@
             [kixi.comms.components
              [kafka :as kafka]]
             [kixi.datastore.metadatastore
-             [inmemory :as md-inmemory]]
+             [inmemory :as md-inmemory]
+             [elasticsearch :as md-es]]
             [kixi.datastore.schemastore
              [inmemory :as ss-inmemory]]
             [kixi.datastore.segmentation
@@ -59,7 +60,8 @@
                     :local (local/map->Local {})
                     :s3 (s3/map->S3 {}))
    :metadatastore (case (first (keys (:metadatastore config)))
-                    :inmemory (md-inmemory/map->InMemory {}))
+                    :inmemory (md-inmemory/map->InMemory {})
+                    :elasticsearch (md-es/map->ElasticSearch {}))
    :schemastore (case (first (keys (:schemastore config)))
                     :inmemory (ss-inmemory/map->InMemory {}))
    :segmentation (case (first (keys (:schemastore config)))

--- a/test/kixi/integration/base.clj
+++ b/test/kixi/integration/base.clj
@@ -150,7 +150,6 @@
   ([ugroup id k tries cnt lr]
    (if (<= cnt tries)
      (let [md (get-metadata ugroup id)]
-       (prn "MD: " md)
        (if-not (get-in md [:body k])
          (do
            (when (zero? (mod cnt every-count-tries-emit))

--- a/test/kixi/integration/base.clj
+++ b/test/kixi/integration/base.clj
@@ -150,12 +150,13 @@
   ([ugroup id k tries cnt lr]
    (if (<= cnt tries)
      (let [md (get-metadata ugroup id)]
+       (prn "MD: " md)
        (if-not (get-in md [:body k])
          (do
            (when (zero? (mod cnt every-count-tries-emit))
-             (println "Waited" cnt "times for" k "to be metadata for" id))
+             (println "Waited" cnt "times for" k "to be in metadata for" id))
            (Thread/sleep wait-per-try)
-           (recur id k ugroup tries (inc cnt) md))
+           (recur ugroup id k tries (inc cnt) md))
          md))
      (throw (Exception. (str "Metadata key never appeared: " k ". Response: " lr))))))
 
@@ -190,8 +191,9 @@
   [& {:as args}]
   (let [pfr (apply post-file-flex (mapcat identity (seq args)))]
     (when (accept-status (:status pfr))
-      (wait-for-metadata-key (extract-id pfr) ::ms/id
-                             (:user-groups args)))
+      (wait-for-metadata-key (:user-groups args) 
+                             (extract-id pfr)
+                             ::ms/id))
     pfr))
 
 (defn post-file

--- a/test/kixi/integration/metadata_test.clj
+++ b/test/kixi/integration/metadata_test.clj
@@ -43,7 +43,6 @@
                        @metadata-file-schema-id)]
     (when-created pfr
       (let [metadata-response (wait-for-metadata-key (extract-id pfr) ::ms/structural-validation)]
-        (clojure.pprint/pprint (:body metadata-response))
         (is-submap
          {:status 200
           :body {::ms/id (extract-id pfr)

--- a/test/kixi/integration/metadata_test.clj
+++ b/test/kixi/integration/metadata_test.clj
@@ -43,6 +43,7 @@
                        @metadata-file-schema-id)]
     (when-created pfr
       (let [metadata-response (wait-for-metadata-key (extract-id pfr) ::ms/structural-validation)]
+        (clojure.pprint/pprint (:body metadata-response))
         (is-submap
          {:status 200
           :body {::ms/id (extract-id pfr)


### PR DESCRIPTION
Migrates the DataStore from inmemory file metadata storage to elastic search.

They'll be more to do here as the type in elastic search will need to be evolved as we extend the metadata. Also all the elements we may wish to query by might not be covered. Will pick that stuff up when the query api get's put together.