### PR TITLE
Implement S3 storage for filestore

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,9 @@ test:
   pre:
     - ./test-resources/create-test-files.sh
     - docker-compose up -d
+  override:
+    - lein test
+    - SYSTEM_PROFILE=circleci lein test
 
 deployment:
   #production:

--- a/project.clj
+++ b/project.clj
@@ -45,7 +45,7 @@
                  [org.slf4j/log4j-over-slf4j ~slf4j-version]
                  [org.slf4j/jul-to-slf4j ~slf4j-version]
                  [org.slf4j/jcl-over-slf4j ~slf4j-version]
-                 [yada "1.1.41" :exclusions [com.fasterxml.jackson.core/jackson-core]]]
+                 [yada "1.1.43" :exclusions [com.fasterxml.jackson.core/jackson-core]]]
 
   :exclusions [cheshire]
 

--- a/project.clj
+++ b/project.clj
@@ -45,7 +45,9 @@
                  [org.slf4j/log4j-over-slf4j ~slf4j-version]
                  [org.slf4j/jul-to-slf4j ~slf4j-version]
                  [org.slf4j/jcl-over-slf4j ~slf4j-version]
-                 [yada "1.1.43" :exclusions [com.fasterxml.jackson.core/jackson-core]]]
+                 [mantree/experimental-yada "1.1.44" :exclusions [com.fasterxml.jackson.core/jackson-core]]
+;                 [yada "1.1.43" :exclusions [com.fasterxml.jackson.core/jackson-core]]
+                 ]
 
   :exclusions [cheshire]
 

--- a/project.clj
+++ b/project.clj
@@ -8,13 +8,15 @@
   :dependencies [[aero "1.0.0"]
                  [aleph "0.4.2-alpha8"]
                  [amazonica "0.3.74" :exclusions [ch.qos.logback/logback-classic
+                                                  com.amazonaws/aws-java-sdk
                                                   com.fasterxml.jackson.dataformat/jackson-dataformat-cbor
                                                   commons-logging
                                                   com.fasterxml.jackson.core/jackson-databind
                                                   com.fasterxml.jackson.core/jackson-core
                                                   org.apache.httpcomponents/httpclient
                                                   joda-time]]
-                 [bidi "2.0.9"]
+                 [com.amazonaws/aws-java-sdk "1.11.53" :exclusions [joda-time]]
+                 [bidi "2.0.12"]
                  [byte-streams "0.2.2"]
                  [clj-http "2.2.0"]
                  [clj-time "0.12.0"]
@@ -43,7 +45,7 @@
                  [org.slf4j/log4j-over-slf4j ~slf4j-version]
                  [org.slf4j/jul-to-slf4j ~slf4j-version]
                  [org.slf4j/jcl-over-slf4j ~slf4j-version]
-                 [yada "1.1.33" :exclusions [com.fasterxml.jackson.core/jackson-core]]]
+                 [yada "1.1.41" :exclusions [com.fasterxml.jackson.core/jackson-core]]]
 
   :exclusions [cheshire]
 

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -22,7 +22,8 @@
                                     "service" ^:ref [:service-name]
                                     "taskid" #or [#env MESOS_TASK_ID #rand-uuid "rand"]}
                              :seconds #profile {:staging 60
-                                                :local 1}}}
+                                                :local 1
+                                                :circleci 30}}}
  :logging {:level :error ; e/o #{:trace :debug :info :warn :error :fatal :report}
            ;; Control log filtering by namespaces/patterns. Useful for turning off
            ;; logging in noisy libraries, etc.:

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -41,12 +41,12 @@
                                   :endpoint "s3.eu-central-1.amazonaws.com"}}}
  :metadatastore {:elasticsearch #profile {:local {:host "localhost"
                                                   :port 9200}
-                                          :circleci {:host "search-sandpit-elasticsearch-xijn4teq3gmimkpzpy2ivbbnbm.eu-central-1.es.amazonaws.com"
-                                                     :port 80}}}
+                                          :circleci {:host "localhost"
+                                                     :port 9200}}}
  :schemastore {:elasticsearch #profile {:local {:host "localhost"
                                                 :port 9200}
-                                        :circleci {:host "search-sandpit-elasticsearch-xijn4teq3gmimkpzpy2ivbbnbm.eu-central-1.es.amazonaws.com"
-                                                   :port 80}}}
+                                        :circleci {:host "localhost"
+                                                   :port 9200}}}
  :segmentation {:inmemory {}}
  :communications {:kafka #profile {:local {:host "127.0.0.1"
                                            :port 2181

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -31,13 +31,13 @@
            :ns-blacklist ["org.eclipse.jetty"]}
  :filestore #profile {:local {:local {:base-dir "/kixi-datastore"}
                                         ;To use S3 locally, remove :local config and set some keys.
-                              :s3 {:bucket "city-data-store-file-store"
+                              :s3 {:bucket "kixi-data-store-file-store"
                                    :endpoint "s3.eu-central-1.amazonaws.com"
                                    :access-key ""
                                    :secret-key ""}}
-                      :circleci {:s3 {:bucket "city-data-store-file-store"
+                      :circleci {:s3 {:bucket "kixi-data-store-file-store"
                                       :endpoint "s3.eu-central-1.amazonaws.com"}}
-                      :prod {:s3 {:bucket "city-data-store-file-store"
+                      :prod {:s3 {:bucket "kixi-data-store-file-store"
                                   :endpoint "s3.eu-central-1.amazonaws.com"}}}
  :metadatastore {:elasticsearch {:host #profile {:local "localhost"
                                                  :circleci "localhost"}

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -36,9 +36,9 @@
                                    :access-key ""
                                    :secret-key ""}}
                       :circleci {:s3 {:bucket "kixi-data-store-file-store"
-                                      :endpoint "s3.eu-central-1.amazonaws.com"}}
+                                      :region "eu-central-1"}}
                       :prod {:s3 {:bucket "kixi-data-store-file-store"
-                                  :endpoint "s3.eu-central-1.amazonaws.com"}}}
+                                  :region "eu-central-1"}}}
  :metadatastore {:elasticsearch {:host #profile {:local "localhost"
                                                  :circleci "localhost"}
                                  :port 9200}}

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -1,7 +1,8 @@
 {:service-name "kixi.datastore"
  :web-server {:port #or [#env WEB_SERVER_PORT 8080]}
  :metrics {:influx-reporter {:host #profile {:staging "172.20.0.48"
-                                             :local "localhost"}                
+                                             :local "localhost"
+                                             :circleci "localhost"}                
                              :port 8086
                                         ;                             :auth 
                              :connect-timeout 1500
@@ -28,20 +29,29 @@
            ;;:ns-whitelist  ["whiner.*"] #_["my-app.foo-ns"]
            :ns-blacklist ["org.eclipse.jetty"]}
  :filestore #profile {:local {:local {:base-dir "/kixi-datastore"}
-                              ;To use S3 locally, remove :local config and set some keys.
+                                        ;To use S3 locally, remove :local config and set some keys.
                               :s3 {:bucket "city-data-store-file-store"
                                    :endpoint "s3.eu-central-1.amazonaws.com"
                                    :access-key ""
-                                   :secret-key ""}}                      
+                                   :secret-key ""}}
+                      :circleci {:s3 {:bucket "city-data-store-file-store"
+                                      :endpoint "s3.eu-central-1.amazonaws.com"}}
                       :prod {:s3 {:bucket "city-data-store-file-store"
                                   :endpoint "s3.eu-central-1.amazonaws.com"}}}
- :metadatastore {:elasticsearch {:host #profile {:local "localhost"}
+ :metadatastore {:elasticsearch {:host #profile {:local "localhost"
+                                                 :circleci "localhost"}
                                  :port 9200}}
- :schemastore {:elasticsearch {:host #profile {:local "localhost"}
+ :schemastore {:elasticsearch {:host #profile {:local "localhost"
+                                               :circleci "localhost"}
                                :port 9200}}
  :segmentation {:inmemory {}}
  :communications {:kafka #profile {:local {:host "127.0.0.1"
                                            :port 2181
                                            :group-id group-id
                                            :consumer-config {:session.timeout.ms 6000
-                                                             :auto.commit.interval.ms 1500}}}}}
+                                                             :auto.commit.interval.ms 1500}}
+                                   :circleci {:host "127.0.0.1"
+                                              :port 2181
+                                              :group-id group-id
+                                              :consumer-config {:session.timeout.ms 6000
+                                                                :auto.commit.interval.ms 1500}}}}}

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -27,7 +27,14 @@
            ;; logging in noisy libraries, etc.:
            ;;:ns-whitelist  ["whiner.*"] #_["my-app.foo-ns"]
            :ns-blacklist ["org.eclipse.jetty"]}
- :filestore {:local {:base-dir "/kixi-datastore"}}
+ :filestore #profile {:local {:local {:base-dir "/kixi-datastore"}
+                              ;To use S3 locally, remove :local config and set some keys.
+                              :s3 {:bucket "city-data-store-file-store"
+                                   :endpoint "s3.eu-central-1.amazonaws.com"
+                                   :access-key ""
+                                   :secret-key ""}}                      
+                      :prod {:s3 {:bucket "city-data-store-file-store"
+                                  :endpoint "s3.eu-central-1.amazonaws.com"}}}
  :metadatastore {:elasticsearch {:host #profile {:local "localhost"}
                                  :port 9200}}
  :schemastore {:elasticsearch {:host #profile {:local "localhost"}

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -36,9 +36,9 @@
                                    :access-key ""
                                    :secret-key ""}}
                       :circleci {:s3 {:bucket "kixi-data-store-file-store"
-                                      :region "eu-central-1"}}
+                                      :endpoint "s3.eu-central-1.amazonaws.com"}}
                       :prod {:s3 {:bucket "kixi-data-store-file-store"
-                                  :region "eu-central-1"}}}
+                                  :endpoint "s3.eu-central-1.amazonaws.com"}}}
  :metadatastore {:elasticsearch {:host #profile {:local "localhost"
                                                  :circleci "localhost"}
                                  :port 9200}}

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -39,12 +39,14 @@
                                       :endpoint "s3.eu-central-1.amazonaws.com"}}
                       :prod {:s3 {:bucket "kixi-data-store-file-store"
                                   :endpoint "s3.eu-central-1.amazonaws.com"}}}
- :metadatastore {:elasticsearch {:host #profile {:local "localhost"
-                                                 :circleci "localhost"}
-                                 :port 9200}}
- :schemastore {:elasticsearch {:host #profile {:local "localhost"
-                                               :circleci "localhost"}
-                               :port 9200}}
+ :metadatastore {:elasticsearch #profile {:local {:host "localhost"
+                                                  :port 9200}
+                                          :circleci {:host "search-sandpit-elasticsearch-xijn4teq3gmimkpzpy2ivbbnbm.eu-central-1.es.amazonaws.com"
+                                                     :port 80}}}
+ :schemastore {:elasticsearch #profile {:local {:host "localhost"
+                                                :port 9200}
+                                        :circleci {:host "search-sandpit-elasticsearch-xijn4teq3gmimkpzpy2ivbbnbm.eu-central-1.es.amazonaws.com"
+                                                   :port 80}}}
  :segmentation {:inmemory {}}
  :communications {:kafka #profile {:local {:host "127.0.0.1"
                                            :port 2181

--- a/src/kixi/datastore/elasticsearch.clj
+++ b/src/kixi/datastore/elasticsearch.clj
@@ -90,7 +90,7 @@
 
 (def apply-attempts 10)
 
-(defn version-conflict
+(defn version-conflict?
   [resp]
   (some
    #(= "version_conflict_engine_exception"
@@ -113,7 +113,7 @@
                          (merge put-opts
                                 (when (:_version curr)
                                   {:version (:_version curr)})))]
-       (if (and (version-conflict resp)
+       (if (and (version-conflict? resp)
                 (pos? tries))
          (recur (dec tries))
          resp)))))

--- a/src/kixi/datastore/filestore.clj
+++ b/src/kixi/datastore/filestore.clj
@@ -6,7 +6,7 @@
 (defprotocol FileStore
   (exists [this id]
     "Checks if there is a file with this id in the store")
-  (output-stream [this id]
+  (output-stream [this id content-length]
     "Returns an outputstream for writing a files contents to")
   (retrieve [this id] 
     "Returns an inputstream for read a files contents from"))

--- a/src/kixi/datastore/filestore/local.clj
+++ b/src/kixi/datastore/filestore/local.clj
@@ -1,5 +1,6 @@
 (ns kixi.datastore.filestore.local
   (:require [clojure.java.io :as io]
+            [clojure.core.async :as async :refer [go]]
             [com.stuartsierra.component :as component]
             [kixi.datastore.filestore :refer [FileStore]]
             [taoensso.timbre :as timbre :refer [error info infof]]))
@@ -11,11 +12,12 @@
       (let [^java.io.File file (io/file dir
                                         id)]
         (.exists file)))
-    (output-stream [this id]
+    (output-stream [this id content-length]
       (let [^java.io.File file (io/file dir 
                                         id)
             _ (.createNewFile file)]
-        (io/output-stream file)))
+        [(go :done)
+         (io/output-stream file)]))
     (retrieve [this id]      
       (let [^java.io.File file (io/file dir
                                         id)]

--- a/src/kixi/datastore/filestore/s3.clj
+++ b/src/kixi/datastore/filestore/s3.clj
@@ -40,11 +40,11 @@
     component/Lifecycle
     (start [component]      
       (if-not creds
-        (let [c (if endpoint 
-                  {:endpoint endpoint
-                   :secret-key secret-key
-                   :access-key access-key}
-                  {:region region})]
+        (let [c (merge {:endpoint endpoint}
+                       (when secret-key 
+                         {:secret-key secret-key})
+                       (when access-key 
+                         {:access-key access-key}))]
           (ensure-bucket c bucket)
           (assoc component
                  :creds

--- a/src/kixi/datastore/filestore/s3.clj
+++ b/src/kixi/datastore/filestore/s3.clj
@@ -1,14 +1,57 @@
 (ns kixi.datastore.filestore.s3
-  (:require [com.stuartsierra.component :as component]
-            [kixi.datastore.filestore :refer [FileStore]]))
+  (:require [amazonica.core :as aws]
+            [amazonica.aws.s3 :as s3]
+            [amazonica.aws.s3transfer :as s3t]
+            [byte-streams :as bs]
+            [clojure.core.async :as async :refer [go]]
+            [com.stuartsierra.component :as component]
+            [kixi.datastore.filestore :as fs :refer [FileStore]]))
+
+(defn ensure-bucket
+  [creds bucket]
+  (when-not (s3/does-bucket-exist creds bucket)
+    (s3/create-bucket creds bucket)))
+
+(def ^Integer buffer-size 
+  "The piped stream must have a buffer size at least as big as the S3 clients: http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/constant-values.html#com.amazonaws.RequestClientOptions.DEFAULT_STREAM_BUFFER_SIZE"
+  (inc 131073))
+
+(defn upload
+  [creds bucket id content-length]
+  (let [in-stream (new java.io.PipedInputStream buffer-size)
+        out-stream (new java.io.PipedOutputStream in-stream)]
+    [(go
+       (s3/put-object creds
+                      bucket id in-stream 
+                      {:content-length content-length}))
+     out-stream]))
 
 (defrecord S3
-    [region bucket key-prefix]
+    [logging region endpoint access-key secret-key bucket client-options creds]
     FileStore
-    (output-stream [this file-meta-data])
-    (retrieve [this file-meta-data])
+    (exists [this id]
+      (s3/does-object-exist creds bucket id))
+    (output-stream [this id content-length]
+      (upload creds bucket id content-length))
+    (retrieve [this id]
+      (when (s3/does-object-exist creds bucket id)
+        (:object-content
+         (s3/get-object creds bucket id))))
     component/Lifecycle
-    (start [component]
-      component)
+    (start [component]      
+      (if-not creds
+        (let [c (if endpoint 
+                  {:endpoint endpoint
+                   :secret-key secret-key
+                   :access-key access-key}
+                  {:region region})]
+          (ensure-bucket c bucket)
+          (assoc component
+                 :creds
+                 c))
+        component))
     (stop [component]
-      component))
+      (if creds
+        (dissoc component
+                :creds)
+        component)))

--- a/src/kixi/datastore/segmentation/inmemory.clj
+++ b/src/kixi/datastore/segmentation/inmemory.clj
@@ -90,7 +90,7 @@
   [filestore communications]
   (fn [basemetadata request segment-data]
     (bs/transfer (:file segment-data)
-                 (kdfs/output-stream filestore (:id segment-data)))
+                 (second (kdfs/output-stream filestore (:id segment-data) (:size-bytes segment-data))))
     (let [metadata (assoc (select-keys basemetadata
                                        [::ms/type
                                         ::ms/name
@@ -142,7 +142,7 @@
     (segmentate-file-by-column-values (::seg/column-name request))
     (map (partial uploader metadata request))
     doall
-    (map :id)))
+    (mapv :id)))
 
 (defn group-rows-by-column
   [uploader retrieve-file request metadata]

--- a/src/kixi/datastore/system.clj
+++ b/src/kixi/datastore/system.clj
@@ -44,7 +44,7 @@
    :logging [:metrics]
    :communications []
    :web-server [:metrics :logging :filestore :metadatastore :schemastore :communications]
-   :filestore []
+   :filestore [:logging]
    :metadatastore [:communications]
    :schemastore [:communications]
                                         ;   :schema-extracter [:communications :filestore]

--- a/src/kixi/datastore/web_server.clj
+++ b/src/kixi/datastore/web_server.clj
@@ -209,7 +209,7 @@
 
 (defn file-size
   [piece]
-  (let [^String fs (get-in piece [:request-headers :file-size])]
+  (let [^String fs (get-in piece [:request-headers "file-size"])]
     (Long/valueOf fs)))
 
 (defrecord PartConsumer
@@ -218,7 +218,7 @@
     (consume-part [this state part]
       (if (file-part? part)
         (let [id (uuid)
-              complete-chan-r (flush-tiny-file! filestore id part (file-size state))]          
+              complete-chan-r (flush-tiny-file! filestore id part (file-size part))]          
           (-> part
               (assoc :id id
                      :count 1

--- a/test/kixi/integration/base.clj
+++ b/test/kixi/integration/base.clj
@@ -166,10 +166,13 @@
     (vector x)))
 
 (defn post-file-flex
-  [& {:keys [file-name schema-id user-id user-groups sharing]}]
+  [& {:keys [^String file-name schema-id user-id user-groups sharing]}]
   (check-file file-name)
   (let [r (client/post file-url
-                       {:multipart [{:name "file" :content (io/file file-name)}
+                       {:multipart [{:name "file-size"
+                                     :content (str (.length (io/file file-name)))}
+                                    {:name "file"
+                                     :content (io/file file-name)}
                                     {:name "file-metadata" 
                                      :content (encode-json (merge {:name "foo"
                                                                    :header true
@@ -177,7 +180,8 @@
                                                                   (when sharing
                                                                     {:sharing sharing})))}]
                         :headers {"user-id" user-id
-                                  "user-groups" (vec-if-not user-groups)}
+                                  "user-groups" (vec-if-not user-groups)
+                                  "file-size" (str (.length (io/file file-name)))}
                         :throw-exceptions false
                         :accept :json})]
     (if-not (= 500 (:status r)) 

--- a/test/kixi/integration/base.clj
+++ b/test/kixi/integration/base.clj
@@ -55,9 +55,10 @@
 (defn cycle-system-fixture
   [all-tests]
   (repl/start)
-  (instrument-specd-functions)
-  (all-tests)
-  (repl/stop))
+  (try (instrument-specd-functions)
+       (all-tests)
+       (finally
+         (repl/stop))))
 
 (defn uuid
   []
@@ -169,9 +170,7 @@
   [& {:keys [^String file-name schema-id user-id user-groups sharing]}]
   (check-file file-name)
   (let [r (client/post file-url
-                       {:multipart [{:name "file-size"
-                                     :content (str (.length (io/file file-name)))}
-                                    {:name "file"
+                       {:multipart [{:name "file"
                                      :content (io/file file-name)}
                                     {:name "file-metadata" 
                                      :content (encode-json (merge {:name "foo"

--- a/test/kixi/integration/segmentation_test.clj
+++ b/test/kixi/integration/segmentation_test.clj
@@ -90,6 +90,7 @@
               (let [seg-meta-resp (get-metadata uid seg-id)]
                 (is-submap {:status 200
                             :body {::ss/id @small-segmentable-file-schema-id
+                                   ::ms/id seg-id
                                    ::ms/type (::ms/type base-file-meta)
                                    ::ms/provenance {::ms/parent-id base-file-id}
                                    ::ms/size-bytes 27}}

--- a/test/kixi/integration/upload_test.clj
+++ b/test/kixi/integration/upload_test.clj
@@ -52,7 +52,7 @@
       (is (files-match?
            "./test-resources/metadata-12MB-valid.csv"
            (dload-file uid locat)))))
-  (let [r (post-file uid
+  #_(let [r (post-file uid
                      "./test-resources/metadata-344MB-valid.csv"
                      @irrelevant-schema-id)]
     (is (= 201

--- a/test/kixi/integration/upload_test.clj
+++ b/test/kixi/integration/upload_test.clj
@@ -58,16 +58,16 @@
         (is (files-match?
              "./test-resources/metadata-12MB-valid.csv"
              (dload-file uid locat)))))
-    #_(let [r (post-file uid
-                         "./test-resources/metadata-344MB-valid.csv"
-                         @irrelevant-schema-id)]
-        (is (= 201
-               (:status r))
-            (str "Reason: " (parse-json (:body r))))
-        (when-let [locat (get-in r [:headers "Location"])]
-          (is (files-match?
-               "./test-resources/metadata-344MB-valid.csv"
-               (dload-file uid locat)))))
+    (let [r (post-file uid
+                       "./test-resources/metadata-344MB-valid.csv"
+                       @irrelevant-schema-id)]
+      (is (= 201
+             (:status r))
+          (str "Reason: " (parse-json (:body r))))
+      (when-let [locat (get-in r [:headers "Location"])]
+        (is (files-match?
+             "./test-resources/metadata-344MB-valid.csv"
+             (dload-file uid locat)))))
     (finally
       (repl/stop))))
 
@@ -168,9 +168,7 @@
                               "./test-resources/metadata-12MB-valid.csv"
                               @irrelevant-schema-id)))
       (finally
-        (component/stop-system system)
-        (Thread/sleep 5000)
-        (prn "done")))))
+        (component/stop-system system)))))
 
 (comment "The 12mb file gets uploaded in 210 parts, test what happens when the stream dies on the final chunk")
 (deftest upload-output-stream-failure-after-209-writes

--- a/test/kixi/integration/upload_test.clj
+++ b/test/kixi/integration/upload_test.clj
@@ -1,10 +1,17 @@
 (ns kixi.integration.upload-test
   (:require [byte-streams :as bs]
             [clojure.test :refer :all]
+            [com.stuartsierra.component :as component]
+            [clojure.core.async :as async :refer [go]]
             [clj-http.client :as client]
             [clojure.java.io :as io]
             [kixi.integration.base :refer :all]
-            [kixi.datastore.schemastore.conformers :as conformers])
+            [kixi.datastore.schemastore.conformers :as conformers]
+            [kixi.datastore.system :as system]
+            [kixi.repl :as repl]
+            [kixi.datastore.filestore :as fs]
+            [taoensso.timbre :as timbre :refer [error info infof]]
+            [kixi.repl :as repl])
   (:import [java.io
             File
             FileNotFoundException]))
@@ -20,45 +27,180 @@
                                  :sharing {:read [uid]
                                            :use [uid]}}})
 
-
 (defn setup-schema
-  [all-tests]
+  []
   (let [r (post-spec-and-wait uid irrelevant-schema)]
     (if (= 202 (:status r))
       (reset! irrelevant-schema-id (extract-id r))
-      (throw (Exception. "Couldn't post irrelevant-schema"))))
-  (all-tests))
-
-(use-fixtures :once cycle-system-fixture setup-schema)
+      (throw (Exception. "Couldn't post irrelevant-schema")))))
 
 (deftest round-trip-files
-  (let [r (post-file uid
-                     "./test-resources/metadata-one-valid.csv"
-                     @irrelevant-schema-id)]
-    (is (= 201
-           (:status r))
-        (str "Reason: " (parse-json (:body r))))
-    (when-let [locat (get-in r [:headers "Location"])]
-      (is (files-match?
-           "./test-resources/metadata-one-valid.csv"
-           (dload-file uid locat)))))
-  (let [r (post-file uid
-                     "./test-resources/metadata-12MB-valid.csv"
-                     @irrelevant-schema-id)]
-    (is (= 201
-           (:status r))
-        (str "Reason: " (parse-json (:body r))))
-    (when-let [locat (get-in r [:headers "Location"])]
-      (is (files-match?
-           "./test-resources/metadata-12MB-valid.csv"
-           (dload-file uid locat)))))
-  #_(let [r (post-file uid
-                     "./test-resources/metadata-344MB-valid.csv"
-                     @irrelevant-schema-id)]
-    (is (= 201
-           (:status r))
-        (str "Reason: " (parse-json (:body r))))
-    (when-let [locat (get-in r [:headers "Location"])]
-      (is (files-match?
-           "./test-resources/metadata-344MB-valid.csv"
-           (dload-file uid locat))))))
+  (try 
+    (repl/start)
+    (setup-schema)
+    (let [r (post-file uid
+                       "./test-resources/metadata-one-valid.csv"
+                       @irrelevant-schema-id)]
+      (is (= 201
+             (:status r))
+          (str "Reason: " (parse-json (:body r))))
+      (when-let [locat (get-in r [:headers "Location"])]
+        (is (files-match?
+             "./test-resources/metadata-one-valid.csv"
+             (dload-file uid locat)))))
+    (let [r (post-file uid
+                       "./test-resources/metadata-12MB-valid.csv"
+                       @irrelevant-schema-id)]
+      (is (= 201
+             (:status r))
+          (str "Reason: " (parse-json (:body r))))
+      (when-let [locat (get-in r [:headers "Location"])]
+        (is (files-match?
+             "./test-resources/metadata-12MB-valid.csv"
+             (dload-file uid locat)))))
+    #_(let [r (post-file uid
+                         "./test-resources/metadata-344MB-valid.csv"
+                         @irrelevant-schema-id)]
+        (is (= 201
+               (:status r))
+            (str "Reason: " (parse-json (:body r))))
+        (when-let [locat (get-in r [:headers "Location"])]
+          (is (files-match?
+               "./test-resources/metadata-344MB-valid.csv"
+               (dload-file uid locat)))))
+    (finally
+      (repl/stop))))
+
+(defrecord OutputStreamsFailAfterX
+    [x]
+    fs/FileStore
+    (exists [this id]
+      (throw (new IllegalAccessException)))
+    (output-stream [this id content-length]
+      [(go :done)
+       (proxy [java.io.OutputStream] []
+         (write [array start end]
+           (if (pos? @x)
+             (swap! x dec)
+             (throw (new java.io.IOException)))))])
+    (retrieve [this id]
+      (throw (new IllegalAccessException)))
+
+    component/Lifecycle
+    (start [component]
+      component)
+    (stop [component]
+      component))
+
+
+(defrecord ExceptionInChan
+    []
+    fs/FileStore
+    (exists [this id]
+      (throw (new IllegalAccessException)))
+    (output-stream [this id content-length]
+      [(go (throw (new java.io.IOException)))
+       (proxy [java.io.OutputStream] []
+         (write [array start end]
+           true))])
+    (retrieve [this id]
+      (throw (new IllegalAccessException)))
+
+    component/Lifecycle
+    (start [component]
+      component)
+    (stop [component]
+      component))
+
+
+(deftest upload-output-stream-immediate-failure
+  (let [system (-> (system/new-system :local)
+                   (assoc :filestore
+                          (map->OutputStreamsFailAfterX {:x (atom 0)}))
+                   component/start-system)]
+    (setup-schema)
+    (try
+      (let [r (post-file uid
+                         "./test-resources/metadata-one-valid.csv"
+                         @irrelevant-schema-id)]
+        (is (= 500
+               (:status r))
+            (str "Reason: " (parse-json (:body r)))))
+      (comment "This is what should happen with a larger than 1 chunk file"
+               (let [r (post-file uid
+                                  "./test-resources/metadata-12MB-valid.csv"
+                                  @irrelevant-schema-id)]
+                 (is (= 500
+                        (:status r))
+                     (str "Reason: " (parse-json (:body r))))))
+      (comment "This is what currently occurs:")
+      (is (thrown? java.net.SocketException
+                   (post-file uid
+                              "./test-resources/metadata-12MB-valid.csv"
+                              @irrelevant-schema-id)))
+      (finally
+        (component/stop-system system)))))
+
+
+(deftest upload-output-stream-failure-after-2-writes
+  (let [system (-> (system/new-system :local)
+                   (assoc :filestore
+                          (map->OutputStreamsFailAfterX {:x (atom 2)}))
+                   component/start-system)]
+    (setup-schema)
+    (try
+      (let [r (post-file uid
+                         "./test-resources/metadata-one-valid.csv"
+                         @irrelevant-schema-id)]
+        (is (= 201
+               (:status r))
+            (str "Created, as the tiny file will go through in one write")))
+      (comment "This is what should happen with a larger than 1 chunk file"
+               (let [r (post-file uid
+                                  "./test-resources/metadata-12MB-valid.csv"
+                                  @irrelevant-schema-id)]
+                 (is (= 500
+                        (:status r))
+                     (str "Reason: " (parse-json (:body r))))))
+      (comment "This is what currently occurs:")
+      (is (thrown? java.net.SocketException
+                   (post-file uid
+                              "./test-resources/metadata-12MB-valid.csv"
+                              @irrelevant-schema-id)))
+      (finally
+        (component/stop-system system)
+        (Thread/sleep 5000)
+        (prn "done")))))
+
+(comment "The 12mb file gets uploaded in 210 parts, test what happens when the stream dies on the final chunk")
+(deftest upload-output-stream-failure-after-209-writes
+  (let [system (-> (system/new-system :local)
+                   (assoc :filestore
+                          (map->OutputStreamsFailAfterX {:x (atom 209)}))
+                   component/start-system)]
+    (setup-schema)
+    (try
+      (let [r (post-file uid
+                         "./test-resources/metadata-12MB-valid.csv"
+                         @irrelevant-schema-id)]
+        (is (= 500
+               (:status r))
+            (str "Reason: " (parse-json (:body r)))))
+      (finally
+        (component/stop-system system)))))
+
+(deftest upload-channel-exception
+  (let [system (-> (system/new-system :local)
+                   (assoc :filestore
+                          (map->ExceptionInChan {}))
+                   component/start-system)]
+    (setup-schema)
+    (try
+      (let [r (post-file uid
+                         "./test-resources/metadata-12MB-valid.csv"
+                         @irrelevant-schema-id)]
+        (is (= 500
+               (:status r))
+            (str "Reason: " (parse-json (:body r)))))
+      (finally
+        (component/stop-system system)))))

--- a/test/kixi/repl.clj
+++ b/test/kixi/repl.clj
@@ -7,19 +7,22 @@
 (defonce system (atom nil))
 
 (defn start
-  []
-  (when-not @system
-    (try
-      (prn "Starting system")
-      (->> (system/new-system (keyword (env :system-profile "local")))
-           component/start-system
-           (reset! system))
-      (catch Exception e
-        (reset! system (:system (ex-data e)))
-        (throw e)))))
+  ([]
+   (start {}))
+  ([overrides]
+   (when-not @system
+     (try
+       (prn "Starting system")
+       (->> (system/new-system (keyword (env :system-profile "local")))
+            (#(merge % overrides))
+            component/start-system
+            (reset! system))
+       (catch Exception e
+         (reset! system (:system (ex-data e)))
+         (throw e))))))
 
 (def wait-emit-msg (Integer/parseInt (env :wait-emit-msg "5000")))
-(def total-wait-time (Integer/parseInt (env :total-wait-time "600000")))
+(def total-wait-time (Integer/parseInt (env :total-wait-time "1200000")))
 
 (defn keep-circleci-alive
   [kill-chan]
@@ -29,7 +32,7 @@
       (when (and
              (< cnt (/ total-wait-time wait-emit-msg))
              (not= kill-chan port))
-        (print "Waiting for system shutdown")
+        (prn "Waiting for system shutdown")
         (recur (inc cnt))))))
 
 (defn stop

--- a/test/kixi/repl.clj
+++ b/test/kixi/repl.clj
@@ -1,6 +1,7 @@
 (ns kixi.repl
   (:require [com.stuartsierra.component :as component]
-            [kixi.datastore.system :as system]))
+            [kixi.datastore.system :as system]
+            [environ.core :refer [env]]))
 
 (defonce system (atom nil))
 
@@ -9,7 +10,7 @@
   (when-not @system
     (try
       (prn "Starting system")
-      (->> (system/new-system :local)
+      (->> (system/new-system (keyword (env :system-profile "local")))
            component/start-system
            (reset! system))
       (catch Exception e


### PR DESCRIPTION
There is no reliable local S3 implementation at this time, due to the
java sdk being up graded recently to move to chunked upload.

Therefore, when testing locally, by default the s3 layer will not be
used. Need to find a way to get this work correctly on circleci at
least.

There is a bit to be desired around the code at this point. There is no
S3 upload error handling, and the use of a tuple in the return from
output-stream is not very good. Might have to introduce more core.async
to make that clean or just live with this until a better idea occurs.