### PR TITLE
Modify integration tests to work better with Jenkins

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,6 @@ machine:
   services:
     - docker
   environment:
-    wait_tries: 300
     generative_testing_size: 100
     _JAVA_OPTIONS: "-Xms248m -Xmx1024m"
 
@@ -11,7 +10,6 @@ test:
     - ./test-resources/create-test-files.sh
     - docker-compose up -d
   override:
-    - lein test
     - SYSTEM_PROFILE=circleci lein test
 
 deployment:

--- a/deployment/marathon-config.json.template
+++ b/deployment/marathon-config.json.template
@@ -6,6 +6,7 @@
       "privileged": true,
       "parameters": [
          {"key": "env", "value": "ENVIRONMENT=@@ENVIRONMENT@@"},
+         {"key": "env", "value": "JAVA_OPTS=@@JAVA_OPTS@@"},
          {"key": "log-driver", "value": "gelf"},
          {"key": "log-opt", "value": "gelf-address=udp://logstash.@@VPC@@-vpc.kixi:12201"},
          {"key": "label", "value": "cluster=@@ENVIRONMENT@@"},

--- a/deployment/marathon-config.json.template
+++ b/deployment/marathon-config.json.template
@@ -21,7 +21,7 @@
       ]
     }
   },
-  "id": "@@APP_NAME@@@@CANARY@@",
+  "id": "@@APP_NAME@@",
   "constraints": [["hostname", "UNIQUE"]],
   "instances": @@INSTANCE_COUNT@@,
   "cpus": 0.5,

--- a/project.clj
+++ b/project.clj
@@ -32,7 +32,7 @@
                  [digest "1.4.4"]
                  [clojurewerkz/elastisch "3.0.0-beta1"]
                  [environ "1.1.0"]
-                 [kixi/kixi.comms "0.1.21"]
+                 [kixi/kixi.comms "0.1.22"]
                  [manifold "0.1.6-alpha1"]
                  [medley "0.8.3"]
                  [metrics-clojure ~metrics-version]
@@ -47,6 +47,8 @@
                  [org.slf4j/jcl-over-slf4j ~slf4j-version]
                  [org.clojure/test.check "0.9.0"]
                  [yada "1.1.44" :exclusions [com.fasterxml.jackson.core/jackson-core]]]
+
+  :jvm-opts ["-Xmx2g"]
 
   :exclusions [cheshire]
 

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -37,9 +37,9 @@
  :filestore #profile {:local {:local {:base-dir "/kixi-datastore"}
                                         ;To use S3 locally, remove :local config and set some keys.
                               #_:s3 #_{:bucket "kixi-data-store-file-store"
-                                   :endpoint "s3.eu-central-1.amazonaws.com"
-                                   :access-key ""
-                                   :secret-key ""}}
+                                       :endpoint "s3.eu-central-1.amazonaws.com"
+                                       :access-key ""
+                                       :secret-key ""}}
                       :circleci {:s3 {:bucket "kixi-data-store-file-store"
                                       :endpoint "s3.eu-central-1.amazonaws.com"}}
                       :staging {:s3 {:bucket "kixi-data-store-file-store"
@@ -62,11 +62,13 @@
  :communications {:kafka #profile {:local {:host "127.0.0.1"
                                            :port 2181
                                            :consumer-config {:session.timeout.ms 6000
-                                                             :auto.commit.interval.ms 1500}}
+                                                             :auto.commit.interval.ms 1500
+                                                             :max.poll.records 1}}
                                    :circleci {:host "127.0.0.1"
                                               :port 2181
                                               :consumer-config {:session.timeout.ms 6000
-                                                                :auto.commit.interval.ms 1500}}
+                                                                :auto.commit.interval.ms 1500
+                                                                :max.poll.records 1}}
                                    :staging {:host "master.mesos"
                                              :zk-path "/dcos-service-kafka/"
                                              :port 2181

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -1,11 +1,12 @@
 {:service-name "kixi.datastore"
  :web-server #profile {:local {:vhost "localhost"
                                :port 8080}
-                       :circleci {:vhost "localhost"
-                                  :port 8080}
+                       :jenkins {:vhost "localhost"
+                                 :port 8080}
                        :staging {:vhost "kixi.datastore.marathon.mesos"
                                  :port 18080}}
  :metrics {:influx-reporter {:host #profile {:staging "172.20.0.48"
+                                             :jenkins "influxdb.sandpitvpc.kixi"
                                              :local "localhost"
                                              :circleci "localhost"}
                              :port 8086
@@ -28,7 +29,7 @@
                                     "taskid" #or [#env MESOS_TASK_ID #rand-uuid "rand"]}
                              :seconds #profile {:staging 60
                                                 :local 1
-                                                :circleci 30}}}
+                                                :jenkins 30}}}
  :logging {:level :error ; e/o #{:trace :debug :info :warn :error :fatal :report}
            ;; Control log filtering by namespaces/patterns. Useful for turning off
            ;; logging in noisy libraries, etc.:
@@ -40,22 +41,23 @@
                                        :endpoint "s3.eu-central-1.amazonaws.com"
                                        :access-key ""
                                        :secret-key ""}}
-                      :circleci {:s3 {:bucket "kixi-data-store-file-store"
-                                      :endpoint "s3.eu-central-1.amazonaws.com"}}
+                      :jenkins {:s3 {:bucket "kixi-data-store-file-store"
+                                     :endpoint "s3.eu-central-1.amazonaws.com"}}
                       :staging {:s3 {:bucket "kixi-data-store-file-store"
                                      :endpoint "s3.eu-central-1.amazonaws.com"}}
                       :prod {:s3 {:bucket "kixi-data-store-file-store"
                                   :endpoint "s3.eu-central-1.amazonaws.com"}}}
  :metadatastore {:elasticsearch #profile {:local {:host "localhost"
                                                   :port 9200}
-                                          :circleci {:host "localhost"
-                                                     :port 9200}
+                                          :jenkins {:host "elasticsearch.marathon.mesos"
+                                                    :port 1026}
                                           :staging {:host "elasticsearch.marathon.mesos"
-                                                    :port 1026}}}
+                                                    :port 1026}
+                                          }}
  :schemastore {:elasticsearch #profile {:local {:host "localhost"
                                                 :port 9200}
-                                        :circleci {:host "localhost"
-                                                   :port 9200}
+                                        :jenkins {:host "elasticsearch.marathon.mesos"
+                                                  :port 1026}
                                         :staging {:host "elasticsearch.marathon.mesos"
                                                   :port 1026}}}
  :segmentation {:inmemory {}}
@@ -64,11 +66,12 @@
                                            :consumer-config {:session.timeout.ms 6000
                                                              :auto.commit.interval.ms 1500
                                                              :max.poll.records 1}}
-                                   :circleci {:host "127.0.0.1"
-                                              :port 2181
-                                              :consumer-config {:session.timeout.ms 6000
-                                                                :auto.commit.interval.ms 1500
-                                                                :max.poll.records 1}}
+                                   :jenkins {:host "master.mesos"
+                                             :port 2181
+                                             :zk-path "/dcos-service-kafka/"
+                                             :consumer-config {:session.timeout.ms 6000
+                                                               :auto.commit.interval.ms 1500
+                                                               :max.poll.records 1}}
                                    :staging {:host "master.mesos"
                                              :zk-path "/dcos-service-kafka/"
                                              :port 2181

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -65,15 +65,20 @@
                                            :port 2181
                                            :consumer-config {:session.timeout.ms 6000
                                                              :auto.commit.interval.ms 1500
-                                                             :max.poll.records 1}}
+                                                             :max.poll.records 1
+                                                             :poll-timeout 10}}
                                    :jenkins {:host "master.mesos"
                                              :port 2181
                                              :zk-path "/dcos-service-kafka/"
+                                             :topics {:command "command-datastore-testing"
+                                                      :event "event-datastore-testing"}
                                              :consumer-config {:session.timeout.ms 6000
                                                                :auto.commit.interval.ms 1500
-                                                               :max.poll.records 1}}
+                                                               :max.poll.records 1
+                                                               :poll-timeout 10}}
                                    :staging {:host "master.mesos"
                                              :zk-path "/dcos-service-kafka/"
                                              :port 2181
                                              :consumer-config {:session.timeout.ms 6000
-                                                               :auto.commit.interval.ms 1500}}}}}
+                                                               :auto.commit.interval.ms 1500
+                                                               :poll-timeout 10}}}}}

--- a/src/kixi/datastore/filestore.clj
+++ b/src/kixi/datastore/filestore.clj
@@ -18,12 +18,13 @@
 
 (defn create-upload-cmd-handler
   [link-fn]
-  (fn [_]
+  (fn [e]
     (let [id (uuid)]
       {:kixi.comms.event/key :kixi.datastore.filestore/upload-link-created
        :kixi.comms.event/version "1.0.0"
        :kixi.comms.event/payload {::upload-link (link-fn id)
-                                  ::id id}})))
+                                  ::id id
+                                  :kixi.user/id (get-in e [:kixi.comms.command/user :kixi.user/id])}})))
 
 (defn attach-command-handlers
   [comms {:keys [link-creator

--- a/src/kixi/datastore/web_server.clj
+++ b/src/kixi/datastore/web_server.clj
@@ -40,10 +40,6 @@
       (clojure.string/split #",")
       vec-if-not))
 
-(defn say-hello [ctx]
-  (info "Saying hello")
-  (str "Hello " (get-in ctx [:parameters :query :p]) "!\n"))
-
 (defn yada-timbre-logger
   [ctx]
   (when (= 500 (get-in ctx [:response :status]))
@@ -277,7 +273,9 @@
   "Create the URI route structure for our application."
   [metrics filestore metadatastore communications schemastore]
   [""
-   [(service-routes metrics filestore metadatastore communications schemastore)   
+   [(service-routes metrics filestore metadatastore communications schemastore)  
+ 
+    ["/healthcheck" healthcheck]
 
     ["/metrics" (yada/resource (:expose-metrics-resource metrics))]
 

--- a/src/kixi/datastore/web_server.clj
+++ b/src/kixi/datastore/web_server.clj
@@ -120,21 +120,6 @@
       (append-error-interceptor
        yada.interceptors/create-response (:record-ctx-metrics metrics))))
 
-(defn hello-parameters-resource
-  [metrics]
-  (resource
-   metrics
-   {:methods
-    {:get
-     {:parameters {:query {:p s/Str}}
-      :produces "text/plain"
-      :response say-hello}}}))
-
-(defn hello-routes
-  [metrics]
-  ["" [["/hello" (yada/handler "Hello World!\n")]
-       ["/hello-param" (hello-parameters-resource metrics)]]])
-
 (defn uuid
   []
   (str (java.util.UUID/randomUUID)))
@@ -292,29 +277,9 @@
   "Create the URI route structure for our application."
   [metrics filestore metadatastore communications schemastore]
   [""
-   [(hello-routes metrics)
-    (service-routes metrics filestore metadatastore communications schemastore)
-    ["/healthcheck" healthcheck]
-
-    #_      ["/api" (-> roots
-                        ;; Wrap this route structure in a Swagger
-                        ;; wrapper. This introspects the data model and
-                        ;; provides a swagger.json file, used by Swagger UI
-                        ;; and other tools.
-                        (yada/swaggered
-                         {:info {:title "Kixi Datastore"
-                                 :version "1.0"
-                                 :description "Testing api resource UI"}
-                          :basePath "/api"})
-                        ;; Tag it so we can create an href to this API
-                        (tag :edge.resources/api))]
+   [(service-routes metrics filestore metadatastore communications schemastore)   
 
     ["/metrics" (yada/resource (:expose-metrics-resource metrics))]
-
-    ;; Swagger UI
-    ["/swagger" (-> (new-webjar-resource "/swagger-ui" {})
-                    ;; Tag it so we can create an href to the Swagger UI
-                    (tag :edge.resources/swagger))]
 
     ;; This is a backstop. Always produce a 404 if we ge there. This
     ;; ensures we never pass nil back to Aleph.

--- a/test/kixi/integration/base.clj
+++ b/test/kixi/integration/base.clj
@@ -501,14 +501,12 @@
   [uid id]
   (dload-file uid (file-url id)))
 
-(defn setup-schema
-  [uid schema id-atom]
-  (fn [all-tests]
-    (let [r (send-spec uid schema)]
-      (if (= 200 (:status r))
-        (reset! id-atom (::ss/id (extract-schema r)))
-        (throw (Exception. (str "Couldn't post small-segmentable-file-schema. Resp: " r)))))
-    (all-tests)))
+(defn schema->schema-id
+  [schema]
+  (let [r (send-spec (get-in schema [::ss/provenance :kixi.user/id]) schema)]
+    (if (= 200 (:status r))
+      (::ss/id (extract-schema r))
+      (throw (Exception. (str "Couldn't post small-segmentable-file-schema. Resp: " r))))))
 
 (defmacro has-status
   [status resp]

--- a/test/kixi/integration/metadata_test.clj
+++ b/test/kixi/integration/metadata_test.clj
@@ -103,6 +103,7 @@
 (deftest small-file-invalid-schema
   (let [uid (uuid)]
     (is-file-metadata-rejected
+     uid
      #(send-file-and-metadata-no-wait
        (create-metadata
         uid

--- a/test/kixi/integration/metadata_test.clj
+++ b/test/kixi/integration/metadata_test.clj
@@ -1,51 +1,49 @@
 (ns kixi.integration.metadata-test
-  (:require [clojure.test :refer :all]
-            [clojure.spec.test :refer [with-instrument-disabled]]
+  (:require [clojure.spec.test :refer [with-instrument-disabled]]
+            [clojure.test :refer :all]
             [kixi.datastore
-             [metadata-creator :as mdc]
              [metadatastore :as ms]
-             [schemastore :as ss]
-             [web-server :as ws]]
+             [schemastore :as ss]]
             [kixi.integration.base :as base :refer :all]))
 
 (alias 'ms 'kixi.datastore.metadatastore)
 
-(def uid (uuid))
+(defn metadata-file-schema
+  [uid]
+  {::ss/name ::metadata-file-schema
+   ::ss/schema {::ss/type "list"
+                ::ss/definition [:cola {::ss/type "integer"}
+                                 :colb {::ss/type "integer"}]}
+   ::ss/provenance {::ss/source "upload"
+                    :kixi.user/id uid}
+   ::ss/sharing {::ss/read [uid]
+                 ::ss/use [uid]}})
 
-;(def post-file (partial base/post-file uid))
-;(def wait-for-metadata-key (partial base/wait-for-metadata-key uid))
-
-(def metadata-file-schema-id (atom nil))
-(def metadata-file-schema {::ss/name ::metadata-file-schema
-                           ::ss/schema {::ss/type "list"
-                                        ::ss/definition [:cola {::ss/type "integer"}
-                                                         :colb {::ss/type "integer"}]}
-                           ::ss/provenance {::ss/source "upload"
-                                            :kixi.user/id uid}
-                           ::ss/sharing {::ss/read [uid]
-                                         ::ss/use [uid]}})
+(def get-schema-id (comp schema->schema-id metadata-file-schema))
 
 (use-fixtures :once
   cycle-system-fixture
-  extract-comms
-  (setup-schema uid metadata-file-schema metadata-file-schema-id))
+  extract-comms)
 
 (deftest unknown-file-401
-  (let [sr (get-metadata uid "foo")]
+  (let [uid (uuid)
+        sr (get-metadata uid "foo")]
     (unauthorised sr)))
 
 (deftest small-file
-  (let [metadata-response (send-file-and-metadata
+  (let [uid (uuid)
+        schema-id (get-schema-id uid)
+        metadata-response (send-file-and-metadata
                            (create-metadata
                             uid
                             "./test-resources/metadata-one-valid.csv"
-                            @metadata-file-schema-id))]
+                            schema-id))]
     (when-success metadata-response
       (let [metadata-response (wait-for-metadata-key uid (extract-id metadata-response) ::ms/structural-validation)]
         (is-submap
          {:status 200
           :body {::ms/id (extract-id metadata-response)
-                 ::ms/schema {::ss/id @metadata-file-schema-id
+                 ::ms/schema {::ss/id schema-id
                               :kixi.user/id uid}
                  ::ms/type "stored"
                  ::ms/file-type "csv"
@@ -58,7 +56,8 @@
          metadata-response)))))
 
 (deftest small-file-no-schema
-  (let [metadata-response (send-file-and-metadata
+  (let [uid (uuid)
+        metadata-response (send-file-and-metadata
                            (create-metadata
                             uid
                             "./test-resources/metadata-one-valid.csv"))]
@@ -76,18 +75,20 @@
        metadata-response))))
 
 (deftest small-file-no-header
-  (let [metadata-response (send-file-and-metadata
+  (let [uid (uuid)
+        schema-id (get-schema-id uid)
+        metadata-response (send-file-and-metadata
                            (assoc (create-metadata
                                    uid
                                    "./test-resources/metadata-one-valid-no-header.csv"
-                                   @metadata-file-schema-id)
+                                   schema-id)
                                   ::ms/header false))]
     (when-success metadata-response
       (let [metadata-response (wait-for-metadata-key uid (extract-id metadata-response) ::ms/structural-validation)]
         (is-submap
          {:status 200
           :body {::ms/id (extract-id metadata-response)
-                 ::ms/schema {::ss/id @metadata-file-schema-id
+                 ::ms/schema {::ss/id schema-id
                               :kixi.user/id uid}
                  ::ms/type "stored"
                  ::ms/file-type "csv"
@@ -100,40 +101,44 @@
          metadata-response)))))
 
 (deftest small-file-invalid-schema
-  (is-file-metadata-rejected
-   #(send-file-and-metadata-no-wait
-     (create-metadata
-      uid
-      "./test-resources/metadata-one-valid.csv"
-      "003ba24c-2830-4f28-b6af-905d6215ea1c")) ;; schema doesn't exist
-   {:reason :schema-unknown}))
+  (let [uid (uuid)]
+    (is-file-metadata-rejected
+     #(send-file-and-metadata-no-wait
+       (create-metadata
+        uid
+        "./test-resources/metadata-one-valid.csv"
+        "003ba24c-2830-4f28-b6af-905d6215ea1c")) ;; schema doesn't exist
+     {:reason :schema-unknown})))
 
 (comment "with-instument-disabled just doesn't seem to work here. Investigate!"
-  (deftest small-file-invalid-metadata
-    (with-instrument-disabled
-      (let [resp (send-file-and-metadata
-                  (dissoc
-                   (create-metadata
-                    uid
-                    "./test-resources/metadata-one-valid.csv"
-                    @metadata-file-schema-id)
-                   ::ms/size-bytes))]
-        (is-submap {:reason :metadata-invalid}
-                   (:kixi.comms.event/payload resp))))))
+         (deftest small-file-invalid-metadata
+           (with-instrument-disabled
+             (let [uid (uuid)
+                   resp (send-file-and-metadata
+                         (dissoc
+                          (create-metadata
+                           uid
+                           "./test-resources/metadata-one-valid.csv"
+                           @metadata-file-schema-id)
+                          ::ms/size-bytes))]
+               (is-submap {:reason :metadata-invalid}
+                          (:kixi.comms.event/payload resp))))))
 
 (deftest small-file-invalid-data
-  (let [metadata-response (send-file-and-metadata
+  (let [uid (uuid)
+        schema-id (get-schema-id uid)
+        metadata-response (send-file-and-metadata
                            (create-metadata
                             uid
                             "./test-resources/metadata-one-invalid.csv"
-                            @metadata-file-schema-id))]
+                            schema-id))]
     (when-success metadata-response
       (let [metadata-response (wait-for-metadata-key uid (extract-id metadata-response) ::ms/structural-validation)]
         (is-submap
          {:status 200
           :body {::ms/id (extract-id metadata-response)
                  ::ms/schema {:kixi.user/id uid
-                              ::ss/id @metadata-file-schema-id}
+                              ::ss/id schema-id}
                  ::ms/type "stored"
                  ::ms/file-type "csv"
                  ::ms/name "./test-resources/metadata-one-invalid.csv"

--- a/test/kixi/integration/search/paging_test.clj
+++ b/test/kixi/integration/search/paging_test.clj
@@ -31,16 +31,17 @@
              metadata))]
     (wait-for-pred
      #(= total-files
-         (get-in (search-metadata uid [])
+         (get-in (search-metadata uid [::ms/meta-read])
                  [:body :paging :total])))
+
     (is-submap {:body {:paging {:total total-files}}}
-               (search-metadata uid []))
+               (search-metadata uid [::ms/meta-read]))
 
     (checking "various combinations of index and count return correct items"
               sample-size
               [dex (gen/elements (range total-files))
                cnt (gen/elements (range total-files))]
-              (let [resp (search-metadata uid [] dex cnt)]
+              (let [resp (search-metadata uid [::ms/meta-read] dex cnt)]
                 (is-submap {:body {:paging {:total total-files
                                             :index dex
                                             :count (min (- total-files
@@ -57,7 +58,7 @@
               [dex (gen/such-that (partial (complement (set (range total-files))))
                                   (gen/int)
                                   such-that-size)]
-              (let [resp (search-metadata uid [] dex nil)]
+              (let [resp (search-metadata uid [::ms/meta-read] dex nil)]
                 (if (pos? dex)
                   (is-submap {:body {:items []
                                      :paging {:total total-files
@@ -73,7 +74,7 @@
               [cnt (gen/such-that (partial (complement (set (range total-files)))) 
                                   (gen/int) 
                                   such-that-size)]
-              (let [resp (search-metadata uid [] nil cnt)]
+              (let [resp (search-metadata uid [::ms/meta-read] nil cnt)]
                 (if (pos? cnt)
                   (is-submap {:body {:paging {:total total-files
                                               :index 0

--- a/test/kixi/integration/sharing_test.clj
+++ b/test/kixi/integration/sharing_test.clj
@@ -57,7 +57,7 @@
    ;[[:file :sharing ::ms/meta-visible]] []
    [[:file :sharing ::ms/meta-read]] [get-metadata]
    ;[[:file :sharing ::ms/meta-update]] []
-   [[:schema :sharing ::ss/read]] [get-spec] ;;WTF These activites should be namespaced like the others!!!
+   [[:schema :sharing ::ss/read]] [get-spec]
    [[:schema :sharing ::ss/use]] [post-file-using-schema]
    })
 

--- a/test/kixi/integration/spec_test.clj
+++ b/test/kixi/integration/spec_test.clj
@@ -8,67 +8,14 @@
 (def uuid-regex
   #"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
 
-(def uid (uuid))
-
-(def send (partial send-spec uid))
-(def send-no-wait (partial send-spec-no-wait uid))
-
 (def location-regex
   (re-pattern (str #"schema\/" uuid-regex)))
 
 (use-fixtures :once cycle-system-fixture extract-comms)
 
 (deftest good-round-trip
-  (let [schema {::ss/name ::new-good-spec-a
-                ::ss/provenance {::ss/source "upload"
-                                 :kixi.user/id uid}
-                ::ss/schema {::ss/type "integer-range"
-                             ::ss/min 3
-                             ::ss/max 10}
-                ::ss/sharing {::ss/read [uid]
-                          ::ss/use [uid]}}
-        r2 (send-spec uid schema)]
-    (when-success r2
-      (is-submap (add-ns-to-keys ::ss/_ (dissoc schema ::ss/name ::ss/sharing ::ss/provenance))
-                 (extract-schema r2)))))
-
-
-(deftest unknown-spec-404
-  (let [r-g (get-spec uid "c0bbb46f-9a31-47c2-b30c-62eba45470d4")]
-    (not-found r-g)))
-
-(deftest good-spec-202
-  (success
-   (send {::ss/name ::good-spec-a
-          ::ss/provenance {::ss/source "upload"
-                           :kixi.user/id uid}
-          ::ss/schema {::ss/type "integer-range"
-                       ::ss/min 3
-                       ::ss/max 10}
-          ::ss/sharing {::ss/read [uid]
-                        ::ss/use [uid]}}))
-  (success
-   (send {::ss/name ::good-spec-b
-          ::ss/provenance {::ss/source "upload"
-                           :kixi.user/id uid}
-          ::ss/schema {::ss/type "integer"}
-          ::ss/sharing {::ss/read [uid]
-                        ::ss/use [uid]}}))
-  (success
-   (send {::ss/name ::good-spec-c
-          ::ss/provenance {::ss/source "upload"
-                           :kixi.user/id uid}
-          ::ss/schema {::ss/type "list"
-                       ::ss/definition [:foo {::ss/type "integer"}
-                                        :bar {::ss/type "integer"}
-                                        :baz {::ss/type "integer-range"
-                                              ::ss/min 3
-                                              ::ss/max 10}]}
-          ::ss/sharing {::ss/read [uid]
-                        ::ss/use [uid]}})))
-
-(deftest good-spec-202-with-reference
-  (let [schema {::ss/name ::ref-good-spec-a
+  (let [uid (uuid)
+        schema {::ss/name ::new-good-spec-a
                 ::ss/provenance {::ss/source "upload"
                                  :kixi.user/id uid}
                 ::ss/schema {::ss/type "integer-range"
@@ -76,30 +23,87 @@
                              ::ss/max 10}
                 ::ss/sharing {::ss/read [uid]
                               ::ss/use [uid]}}
-        r1       (send schema)]
+        r2 (send-spec uid schema)]
+    (when-success r2
+      (is-submap (add-ns-to-keys ::ss/_ (dissoc schema ::ss/name ::ss/sharing ::ss/provenance))
+                 (extract-schema r2)))))
+
+
+(deftest unknown-spec-404
+  (let [uid (uuid)
+        r-g (get-spec uid "c0bbb46f-9a31-47c2-b30c-62eba45470d4")]
+    (not-found r-g)))
+
+(deftest good-spec-202
+  (let [uid (uuid)]
+    (success
+     (send-spec uid 
+                {::ss/name ::good-spec-a
+                 ::ss/provenance {::ss/source "upload"
+                                  :kixi.user/id uid}
+                 ::ss/schema {::ss/type "integer-range"
+                              ::ss/min 3
+                              ::ss/max 10}
+                 ::ss/sharing {::ss/read [uid]
+                               ::ss/use [uid]}}))
+    (success
+     (send-spec uid
+                {::ss/name ::good-spec-b
+                 ::ss/provenance {::ss/source "upload"
+                                  :kixi.user/id uid}
+                 ::ss/schema {::ss/type "integer"}
+                 ::ss/sharing {::ss/read [uid]
+                               ::ss/use [uid]}}))
+    (success
+     (send-spec uid
+                {::ss/name ::good-spec-c
+                 ::ss/provenance {::ss/source "upload"
+                                  :kixi.user/id uid}
+                 ::ss/schema {::ss/type "list"
+                              ::ss/definition [:foo {::ss/type "integer"}
+                                               :bar {::ss/type "integer"}
+                                               :baz {::ss/type "integer-range"
+                                                     ::ss/min 3
+                                                     ::ss/max 10}]}
+                 ::ss/sharing {::ss/read [uid]
+                               ::ss/use [uid]}}))))
+
+(deftest good-spec-202-with-reference
+  (let [uid (uuid)
+        schema {::ss/name ::ref-good-spec-a
+                ::ss/provenance {::ss/source "upload"
+                                 :kixi.user/id uid}
+                ::ss/schema {::ss/type "integer-range"
+                             ::ss/min 3
+                             ::ss/max 10}
+                ::ss/sharing {::ss/read [uid]
+                              ::ss/use [uid]}}
+        r1 (send-spec uid schema)]
     (when-success r1
       (let [id (::ss/id (extract-schema r1))]
         (success
-         (send {::ss/name ::ref-good-spec-b
-                ::ss/provenance {::ss/source "upload"
-                                 :kixi.user/id uid}
-                ::ss/schema {::ss/type "id"
-                             ::ss/id    id}
-                ::ss/sharing {::ss/read [uid]
-                              ::ss/use [uid]}}))
+         (send-spec uid
+                    {::ss/name ::ref-good-spec-b
+                     ::ss/provenance {::ss/source "upload"
+                                      :kixi.user/id uid}
+                     ::ss/schema {::ss/type "id"
+                                  ::ss/id    id}
+                     ::ss/sharing {::ss/read [uid]
+                                   ::ss/use [uid]}}))
         (success
-         (send {::ss/name ::ref-good-spec-b
-                ::ss/provenance {::ss/source "upload"
-                                 :kixi.user/id uid}
-                ::ss/schema {::ss/type "list"
-                             ::ss/definition [:foo {::ss/type "id"
-                                                    ::ss/id   id}
-                                              :bar {::ss/type "integer"}
-                                              :baz {::ss/type "integer-range"
-                                                    ::ss/min 3
-                                                    ::ss/max 10}]}
-                ::ss/sharing {::ss/read [uid]
-                              ::ss/use [uid]}}))))))
+         (send-spec uid
+                    {::ss/name ::ref-good-spec-b
+                     ::ss/provenance {::ss/source "upload"
+                                      :kixi.user/id uid}
+                     ::ss/schema {::ss/type "list"
+                                  ::ss/definition [:foo {::ss/type "id"
+                                                         ::ss/id   id}
+                                                   :bar {::ss/type "integer"}
+                                                   :baz {::ss/type "integer-range"
+                                                         ::ss/min 3
+                                                         ::ss/max 10}]}
+                     ::ss/sharing {::ss/read [uid]
+                                   ::ss/use [uid]}}))))))
 
 (defn rejected-schema
   [event]
@@ -107,37 +111,44 @@
   (is (= :kixi.datastore.schema/rejected (:kixi.comms.event/key event)) (str "Was not rejected: " event)))
 
 (deftest bad-specs
-  (rejected-schema
-   (send {::ss/type "integer"
-          ::ss/provenance {::ss/source "upload"
-                           :kixi.user/id uid}}))
-  (rejected-schema
-   (send {::ss/name :foo
-          ::ss/provenance {::ss/source "upload"
-                           :kixi.user/id uid}
-          ::ss/schema {::ss/type "integer"}}))
-  (rejected-schema
-   (send {::ss/name ::foo
-          ::ss/provenance {::ss/source "upload"
-                           :kixi.user/id uid}
-          ::ss/schema {::ss/type "foo"}}))
-  (rejected-schema
-   (send {::ss/name ::foo
-          ::ss/provenance {::ss/source "upload"
-                           :kixi.user/id uid}
-          ::ss/schema {::ss/type "integer-range"
-                       :foo 1}}))
-  (rejected-schema
-   (send {::ss/name ::foo
-          ::ss/provenance {::ss/source "upload"
-                           :kixi.user/id uid}
-          ::ss/schema {::ss/type "list"
-                       :definition [:foo]}}))
+  (let [uid (uuid)]
+    (rejected-schema
+     (send-spec uid
+                {::ss/type "integer"
+                 ::ss/provenance {::ss/source "upload"
+                                  :kixi.user/id uid}}))
+    (rejected-schema
+     (send-spec uid
+           {::ss/name :foo
+            ::ss/provenance {::ss/source "upload"
+                             :kixi.user/id uid}
+            ::ss/schema {::ss/type "integer"}}))
+    (rejected-schema
+     (send-spec uid
+           {::ss/name ::foo
+            ::ss/provenance {::ss/source "upload"
+                             :kixi.user/id uid}
+            ::ss/schema {::ss/type "foo"}}))
+    (rejected-schema
+     (send-spec uid
+           {::ss/name ::foo
+            ::ss/provenance {::ss/source "upload"
+                             :kixi.user/id uid}
+            ::ss/schema {::ss/type "integer-range"
+                         :foo 1}}))
+    (rejected-schema
+     (send-spec uid
+           {::ss/name ::foo
+            ::ss/provenance {::ss/source "upload"
+                             :kixi.user/id uid}
+            ::ss/schema {::ss/type "list"
+                         :definition [:foo]}}))
 
-  (rejected-schema
-   (send {::ss/name ::foo
-          ::ss/provenance {::ss/source "upload"
-                           :kixi.user/id uid}
-          ::ss/schema {::ss/type "list"
-                       ::ss/definition [:foo
-                                        {::ss/type "foo"}]}})))
+    (rejected-schema
+     (send-spec uid
+           {::ss/name ::foo
+            ::ss/provenance {::ss/source "upload"
+                             :kixi.user/id uid}
+            ::ss/schema {::ss/type "list"
+                         ::ss/definition [:foo
+                                          {::ss/type "foo"}]}}))))

--- a/test/kixi/integration/upload_test.clj
+++ b/test/kixi/integration/upload_test.clj
@@ -52,6 +52,7 @@
 (deftest rejected-when-file-not-uploaded
   (let [uid (uuid)]
     (is-file-metadata-rejected 
+     uid
      #(send-metadata-cmd uid
                          (assoc (create-metadata uid
                                                  "./rejected-when-file-not-uploaded.non-file")
@@ -61,6 +62,7 @@
 (deftest rejected-when-size-incorrect
   (let [uid (uuid)]
     (is-file-metadata-rejected 
+     uid
      #(send-file-and-metadata-no-wait
        (assoc (create-metadata uid
                                "./test-resources/metadata-one-valid.csv")

--- a/test/kixi/integration/upload_test.clj
+++ b/test/kixi/integration/upload_test.clj
@@ -6,19 +6,19 @@
              [metadatastore :as ms]]
             [kixi.integration.base :refer :all]))
 
-(def uid (uuid))
-
 (use-fixtures :once cycle-system-fixture extract-comms)
 
 (deftest create-link-test
-  (let [link (get-upload-link-event uid)]
+  (let [uid (uuid)
+        link (get-upload-link-event uid)]
     (is link)
     (when-let [r link]
       (is (get-in r [:kixi.comms.event/payload :kixi.datastore.filestore/upload-link]))
       (is (get-in r [:kixi.comms.event/payload :kixi.datastore.filestore/id])))))
 
 (deftest round-trip-small-file
-  (let [md-resp (send-file-and-metadata 
+  (let [uid (uuid)
+        md-resp (send-file-and-metadata 
                  (create-metadata uid
                                   "./test-resources/metadata-one-valid.csv"))]
     (when-success md-resp
@@ -28,7 +28,8 @@
              (dload-file uid locat)))))))
 
 (deftest round-trip-12M-file
-  (let [md-resp (send-file-and-metadata 
+  (let [uid (uuid)
+        md-resp (send-file-and-metadata 
                  (create-metadata uid
                                   "./test-resources/metadata-12MB-valid.csv"))]
     (when-success md-resp
@@ -38,7 +39,8 @@
              (dload-file uid locat)))))))
 
 (deftest round-trip-344M-file  
-  (let [md-resp (send-file-and-metadata 
+  (let [uid (uuid)
+        md-resp (send-file-and-metadata 
                  (create-metadata uid
                                   "./test-resources/metadata-344MB-valid.csv"))]
     (when-success md-resp
@@ -48,19 +50,21 @@
              (dload-file uid locat)))))))
 
 (deftest rejected-when-file-not-uploaded
-  (is-file-metadata-rejected 
-   #(send-metadata-cmd uid
-     (assoc (create-metadata uid
-                             "./rejected-when-file-not-uploaded.non-file")
-            ::ms/id (uuid)))
-   {:reason :file-not-exist}))
+  (let [uid (uuid)]
+    (is-file-metadata-rejected 
+     #(send-metadata-cmd uid
+                         (assoc (create-metadata uid
+                                                 "./rejected-when-file-not-uploaded.non-file")
+                                ::ms/id (uuid)))
+     {:reason :file-not-exist})))
 
 (deftest rejected-when-size-incorrect
-  (is-file-metadata-rejected 
-   #(send-file-and-metadata-no-wait
-     (assoc (create-metadata uid
-                             "./test-resources/metadata-one-valid.csv")
-            ::ms/size-bytes 1))
-   {:reason :file-size-incorrect
-    :actual 14
-    :expected 1}))
+  (let [uid (uuid)]
+    (is-file-metadata-rejected 
+     #(send-file-and-metadata-no-wait
+       (assoc (create-metadata uid
+                               "./test-resources/metadata-one-valid.csv")
+              ::ms/size-bytes 1))
+     {:reason :file-size-incorrect
+      :actual 14
+      :expected 1})))

--- a/test/kixi/repl.clj
+++ b/test/kixi/repl.clj
@@ -8,13 +8,16 @@
 
 (defn start
   ([]
-   (start {}))
-  ([overrides]
+   (start {} nil))
+  ([overrides component-subset]
    (when-not @system
      (try
        (prn "Starting system")
        (->> (system/new-system (keyword (env :system-profile "local")))
             (#(merge % overrides))
+            (#(if component-subset
+                (select-keys % component-subset)
+                %))
             component/start-system
             (reset! system))
        (catch Exception e


### PR DESCRIPTION
We're having trouble with tests seeing other tests events. This change ensures that each test uses it's own uuid, which is used for event detection, hopefully bringing an end to this madnesss.