### PR TITLE
Multiple operations on single field supported

### DIFF
--- a/src/kixi/datastore/metadatastore/updates.clj
+++ b/src/kixi/datastore/metadatastore/updates.clj
@@ -17,12 +17,8 @@
   [[spec actions]]
   (eval
    `(s/def ~(update-spec-name spec)
-      ~(s/merge (s/map-of actions
-                          #(s/valid? spec %))
-                #(-> %
-                     keys
-                     count
-                     (= 1))))))
+      ~(s/map-of actions
+                 #(s/valid? spec %)))))
 
 (defn update-map-spec
   [[map-spec fields]]

--- a/test/kixi/integration/datapack_update_test.clj
+++ b/test/kixi/integration/datapack_update_test.clj
@@ -62,7 +62,8 @@
                    uid meta-id
                    {:kixi.datastore.metadatastore.update/description {:set "New Description"}
                     :kixi.datastore.metadatastore.update/source {:set "New Source"}
-                    :kixi.datastore.metadatastore.update/tags {:conj #{"tag" "tag two"}}})]
+                    :kixi.datastore.metadatastore.update/tags {:conj #{"tag" "tag two"}
+                                                               :disj #{"orig-one"}}})]
         (when-event-key event :kixi.datastore.file-metadata/updated
                         (wait-for-pred #(let [metadata (get-metadata uid meta-id)]
                                           (get-in metadata [:body ::ms/description])))
@@ -72,7 +73,7 @@
                                  (get-in updated-metadata [:body ::ms/description])))
                           (is (= "New Source"
                                  (get-in updated-metadata [:body ::ms/source])))
-                          (is (= #{"tag" "tag two" "orig-one" "orig-two"}
+                          (is (= #{"tag" "tag two" "orig-two"}
                                  (get-in updated-metadata [:body ::ms/tags])))))))))
 
 (deftest unreadable-files-arent-removed-when-file-is-added

--- a/test/kixi/unit/dynamodb_test.clj
+++ b/test/kixi/unit/dynamodb_test.clj
@@ -116,25 +116,31 @@
   (let [test-data {::mdu/name {:set "name"}
                    ::mdu/description {:set "description"}
                    ::mdu/tags {:conj #{"add"} 
-                              :disj #{"remove"}}
+                               :disj #{"remove"}}
                    ::lu/license {::lu/usage {:set "license usage"}}}]
-    (is-submap {:update-expr
-                "SET #kixidatastoremetadatastore_name = :aa, #kixidatastoremetadatastore_description = :ab, #kixidatastoremetadatastorelicense_licensekixidatastoremetadatastorelicense_usage = :ae ADD #kixidatastoremetadatastore_tags :ac DELETE #kixidatastoremetadatastore_tags :ad"
-                :expr-attr-names
-                {"#kixidatastoremetadatastore_name"
-                 "kixi.datastore.metadatastore_name",
-                 "#kixidatastoremetadatastore_description"
-                 "kixi.datastore.metadatastore_description",
-                 "#kixidatastoremetadatastore_tags"
-                 "kixi.datastore.metadatastore_tags",
-                 "#kixidatastoremetadatastorelicense_licensekixidatastoremetadatastorelicense_usage"
-                 "kixi.datastore.metadatastore.license_license|kixi.datastore.metadatastore.license_usage"},
-                :expr-attr-vals
-                {":aa" "name"
-                 ":ab" "description"
-                 ":ae" "license usage"
-                 ":ac" #{"add"}
-                 ":ad" #{"remove"}}}
+    (is-submap [{:update-expr
+                  "SET #kixidatastoremetadatastore_name = :aa, #kixidatastoremetadatastore_description = :ab, #kixidatastoremetadatastorelicense_licensekixidatastoremetadatastorelicense_usage = :ae ADD #kixidatastoremetadatastore_tags :ac"
+                  :expr-attr-names
+                  {"#kixidatastoremetadatastore_name"
+                   "kixi.datastore.metadatastore_name",
+                   "#kixidatastoremetadatastore_description"
+                   "kixi.datastore.metadatastore_description",
+                   "#kixidatastoremetadatastore_tags"
+                   "kixi.datastore.metadatastore_tags",
+                   "#kixidatastoremetadatastorelicense_licensekixidatastoremetadatastorelicense_usage"
+                   "kixi.datastore.metadatastore.license_license|kixi.datastore.metadatastore.license_usage"},
+                  :expr-attr-vals
+                  {":aa" "name"
+                   ":ab" "description"
+                   ":ae" "license usage"
+                   ":ac" #{"add"}}}
+                {:update-expr
+                  "DELETE #kixidatastoremetadatastore_tags :ad"
+                  :expr-attr-names
+                  {"#kixidatastoremetadatastore_tags"
+                   "kixi.datastore.metadatastore_tags"},
+                  :expr-attr-vals
+                  {":ad" #{"remove"}}}]
                (db/update-data-map->dynamo-update test-data))))
 
 


### PR DESCRIPTION
Dynamodb doesn't allow multiple updates to the same field in the same
update. The db layer now separates these situations into separate
updates to Dynamo.