### PR TITLE
Metadata create moved to insert if not present

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '2'
 services:
   dynamo:
-    image: rajatvig/dynalite-alpine
+    image: deangiberson/aws-dynamodb-local
     ports:
       - '8000:8000'

--- a/src/kixi/datastore/dynamodb.clj
+++ b/src/kixi/datastore/dynamodb.clj
@@ -231,6 +231,13 @@
                    {id-column id}
                    {:update-map (map->update-map data)}))
 
+(defn insert-data
+  [conn table id-column data]
+  (far/put-item conn table
+                (map-keys keyword (freeze-columns (serialize data)))
+                {:cond-expr "attribute_not_exists(#id)"
+                 :expr-attr-names {"#id" id-column}}))
+
 (def operand->dynamo-op
   {:set ["SET " " = "]
    :rm ["REMOVE " ""]

--- a/src/kixi/datastore/metadatastore/dynamodb.clj
+++ b/src/kixi/datastore/metadatastore/dynamodb.clj
@@ -82,13 +82,11 @@
   [conn update-event]
   (let [metadata (::md/file-metadata update-event)]
     (info "Create: " metadata)
-    (db/merge-data conn
-                   (primary-metadata-table (:profile conn))
-                   id-col
-                   (::md/id metadata)
-                   (-> metadata
-                       sharing-columns->sets
-                       (dissoc ::md/id)))
+    (db/insert-data conn
+                    (primary-metadata-table (:profile conn))
+                    id-col
+                    (sharing-columns->sets
+                        metadata))
     (doseq [activity (keys (::md/sharing metadata))]
       (doseq [group-id (get-in metadata [::md/sharing activity])]
         (insert-activity-row conn group-id activity metadata)))))

--- a/src/kixi/datastore/schemastore/dynamodb.clj
+++ b/src/kixi/datastore/schemastore/dynamodb.clj
@@ -42,13 +42,12 @@
     schema))
 
 (defn persist-new-schema
-  [merge-data]
+  [insert-data]
   (fn [schema]
     (let [id (::ss/id schema)
           schema' (assoc-in schema [::ss/provenance ::ss/created] (time/timestamp))]
       (if (s/valid? ::ss/stored-schema schema')
-        (merge-data id 
-                    (dissoc (inject-tags schema') ::ss/id))
+        (insert-data (inject-tags schema'))
         (error "Tried to persist schema but it was invalid:" schema' (s/explain-data ::ss/stored-schema schema'))))))
 
 (defn extract-tag
@@ -109,7 +108,7 @@
                                    :kixi.datastore.schema/created
                                    "1.0.0"
                                    (comp response-event (persist-new-schema 
-                                                         (partial db/merge-data client (primary-schemastore-table profile) id-col))
+                                                         (partial db/insert-data client (primary-schemastore-table profile) id-col))
                                          :kixi.comms.event/payload))
           (sc/attach-command-handler communications)
           (-> component

--- a/test/kixi/integration/base.clj
+++ b/test/kixi/integration/base.clj
@@ -326,7 +326,8 @@
 
 (defn sink-to
   [a]
-  #(do (async/>!! @a %)
+  #(do (when @a
+         (async/>!! @a %))
        nil))
 
 (defn extract-comms
@@ -405,6 +406,15 @@
      :kixi.user/groups (vec-if-not ugroup)}
     (assoc new-metadata 
            ::ms/id metadata-id))))
+
+(defn send-update-event
+  [uid ugroup event]
+  (c/send-event!
+   @comms
+   :kixi.datastore.file-metadata/updated
+   "1.0.0"
+   event
+   {:kixi.comms.event/partition-key (get-in event [::ms/file-metadata ::ms/id])}))
 
 (defn send-spec-no-wait
   ([uid spec]


### PR DESCRIPTION
Potentially the system could recieve two events to create a single
piece of metadata. The second could over write any and all
information.

Moving the Metadata create step to an insert, with a write condition
that the id doesn't already exist, removes this possibility.