### PR TITLE
Test namespace metadata to allow for selective test runs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -64,8 +64,9 @@
 
   :exclusions [cheshire]
 
-  :test-selectors {:default (complement :integration)
-                   :integration :integration}
+  :test-selectors {:default :all
+                   :integration :integration
+                   :acceptance :acceptance}
 
   :global-vars {*warn-on-reflection* true
                 *assert* false}

--- a/test/kixi/acceptance/kaylee_test.clj
+++ b/test/kixi/acceptance/kaylee_test.clj
@@ -1,4 +1,5 @@
-(ns kixi.integration.kaylee-test
+(ns kixi.acceptance.kaylee-test
+  {:acceptance true}
   (:require [clojure.test :refer :all]
             [kixi.datastore
              [kaylee :as kaylee]

--- a/test/kixi/integration/datapack_update_test.clj
+++ b/test/kixi/integration/datapack_update_test.clj
@@ -1,4 +1,5 @@
 (ns kixi.integration.datapack-update-test
+  {:integration true}
   (:require [clojure.test :refer :all]
             [kixi.datastore
              [metadatastore :as ms]

--- a/test/kixi/integration/dload_test.clj
+++ b/test/kixi/integration/dload_test.clj
@@ -1,4 +1,5 @@
 (ns kixi.integration.dload-test
+  {:integration true}
   (:require [clojure.test :refer :all]
             [clj-http.client :as client]
             [kixi.datastore

--- a/test/kixi/integration/metadata_test.clj
+++ b/test/kixi/integration/metadata_test.clj
@@ -1,4 +1,5 @@
 (ns kixi.integration.metadata-test
+  {:integration true}
   (:require [clojure.spec.test :refer [with-instrument-disabled]]
             [clojure.test :refer :all]
             [kixi.datastore

--- a/test/kixi/integration/metadata_update_test.clj
+++ b/test/kixi/integration/metadata_update_test.clj
@@ -1,4 +1,5 @@
 (ns kixi.integration.metadata-update-test
+  {:integration true}
   (:require [clojure.test :refer :all]
             [kixi.datastore
              [metadatastore :as ms]

--- a/test/kixi/integration/schema.clj
+++ b/test/kixi/integration/schema.clj
@@ -1,4 +1,5 @@
 (ns kixi.integration.schema
+  {:integration true}
   (:require [clojure.spec.test :refer [with-instrument-disabled]]
             [clojure.test :refer :all]
             [kixi.datastore

--- a/test/kixi/integration/search/activity_test.clj
+++ b/test/kixi/integration/search/activity_test.clj
@@ -1,4 +1,5 @@
 (ns kixi.integration.search.activity-test
+  {:integration true}
   (:require [clojure.test :refer :all]
             [clojure.math.combinatorics :as combo :refer [subsets]]
             [kixi.datastore

--- a/test/kixi/integration/search/ordering_test.clj
+++ b/test/kixi/integration/search/ordering_test.clj
@@ -1,4 +1,5 @@
 (ns kixi.integration.search.ordering-test
+  {:integration true}
   (:require [clojure.test :refer :all]
             [clojure.spec.test :refer [with-instrument-disabled]]
             [clojure.core.async :as async]

--- a/test/kixi/integration/search/paging_test.clj
+++ b/test/kixi/integration/search/paging_test.clj
@@ -1,4 +1,5 @@
 (ns kixi.integration.search.paging-test
+  {:integration true}
   (:require [clojure.spec.gen :as gen]
             [clojure.test :refer :all]
             [com.gfredericks.test.chuck.clojure-test :refer [checking]]

--- a/test/kixi/integration/segmentation_test.clj
+++ b/test/kixi/integration/segmentation_test.clj
@@ -1,4 +1,5 @@
 (ns kixi.integration.segmentation-test
+  {:integration true}
   (:require [clojure.test :refer :all]
             [kixi.datastore
              [metadatastore :as ms]

--- a/test/kixi/integration/sharing_test.clj
+++ b/test/kixi/integration/sharing_test.clj
@@ -1,4 +1,5 @@
 (ns kixi.integration.sharing-test
+  {:integration true}
   (:require [clojure.test :refer :all]
             [clojure.math.combinatorics :as combo :refer [subsets]]
             [environ.core :refer [env]]

--- a/test/kixi/integration/spec_test.clj
+++ b/test/kixi/integration/spec_test.clj
@@ -1,4 +1,5 @@
 (ns kixi.integration.spec-test
+  {:integration true}
   (:require [clojure.test :refer :all]
             [kixi.datastore
              [schemastore :as ss]

--- a/test/kixi/integration/upload_test.clj
+++ b/test/kixi/integration/upload_test.clj
@@ -1,4 +1,5 @@
 (ns kixi.integration.upload-test
+  {:integration true}
   (:require [clojure.test :refer :all]
             [kixi.datastore
              [filestore :as fs]


### PR DESCRIPTION
With the addition of the kaylee tests, we finally have some tests that
can't be run in the staging-jenkins mode. Introduced both :integration
and :acceptance metadata on the test namespaces.