### PR TITLE
Add multi-part file uploads via commands/events 

### DIFF
--- a/resources/config.edn
+++ b/resources/config.edn
@@ -32,7 +32,7 @@
                                :staging :json
                                :prod :json}}
  :filestore #profile {:default {:local {:base-dir "/kixi-datastore"}
-                                :local-kinesis {:base-dir "/kixi-datastore"}
+                                #_:local-kinesis #_{:base-dir "/kixi-datastore"}
                                         ;To use S3 locally, remove :local config and set some keys.
                                 #_:s3 #_{:bucket "kixi-data-store-file-store-staging"
                                          :endpoint "s3.eu-central-1.amazonaws.com"

--- a/src/kixi/datastore/filestore/command_handler.clj
+++ b/src/kixi/datastore/filestore/command_handler.clj
@@ -1,0 +1,48 @@
+(ns kixi.datastore.filestore.command-handler
+  (:require [kixi.datastore.schemastore.utils :as sh]))
+
+(sh/alias 'event 'kixi.event)
+(sh/alias 'ms 'kixi.datastore.metadatastore)
+(sh/alias 'fs 'kixi.datastore.filestore)
+(sh/alias 'up 'kixi.datastore.filestore.upload)
+
+(defn uuid
+  []
+  (str (java.util.UUID/randomUUID)))
+
+(defn create-upload-cmd-handler
+  [link-fn]
+  (fn [e]
+    (let [id (uuid)]
+      {:kixi.comms.event/key ::fs/upload-link-created
+       :kixi.comms.event/version "1.0.0"
+       :kixi.comms.event/partition-key id
+       :kixi.comms.event/payload {::fs/upload-link (link-fn id)
+                                  ::fs/id id
+                                  :kixi.user/id (get-in e [:kixi.comms.command/user :kixi.user/id])}})))
+
+(defn create-multi-part-upload-cmd-handler
+  [multi-part-upload-fn]
+  (fn [cmd]
+    (let [part-count (::up/part-count cmd)
+          id (uuid)
+          {:keys [upload-part-urls upload-id]} (multi-part-upload-fn id part-count)]
+      [{::event/type ::fs/multi-part-upload-links-created
+        ::event/version "1.0.0"
+        ::up/part-urls upload-part-urls
+        ::up/id upload-id
+        ::fs/id id}
+       {:partition-key id}])))
+
+(defn create-complete-multi-part-upload-cmd-handler
+  [complete-multi-part-upload-fn]
+  (fn [cmd]
+    (let [{:keys [kixi.datastore.filestore.upload/part-ids
+                  kixi.datastore.filestore/id]} cmd
+          upload-id (:kixi.datastore.filestore.upload/id cmd)]
+      (complete-multi-part-upload-fn id part-ids upload-id)
+      [{::event/type ::fs/multi-part-upload-completed
+        ::event/version "1.0.0"
+        ::up/id upload-id
+        ::fs/id id}
+       {:partition-key id}])))

--- a/src/kixi/datastore/filestore/commands.clj
+++ b/src/kixi/datastore/filestore/commands.clj
@@ -1,0 +1,19 @@
+(ns kixi.datastore.filestore.commands
+  (:require [clojure.spec.alpha :as s]
+            [kixi.comms :as comms]
+            [kixi.datastore.schemastore.utils :as sh]))
+
+(sh/alias 'f 'kixi.datastore.filestore)
+(sh/alias 'up 'kixi.datastore.filestore.upload)
+
+(defmethod comms/command-payload
+  [:kixi.datastore.filestore/create-multi-part-upload-link "1.0.0"]
+  [_]
+  (s/keys :req [::up/part-count]))
+
+(defmethod comms/command-payload
+  [:kixi.datastore.filestore/complete-multi-part-upload "1.0.0"]
+  [_]
+  (s/keys :req [::up/part-ids
+                ::up/id
+                ::f/id]))

--- a/src/kixi/datastore/filestore/events.clj
+++ b/src/kixi/datastore/filestore/events.clj
@@ -1,0 +1,21 @@
+(ns kixi.datastore.filestore.events
+  (:require [clojure.spec.alpha :as s]
+            [kixi.comms :as comms]
+            [kixi.datastore.schemastore.utils :as sh]))
+
+(sh/alias 'ms 'kixi.datastore.metadatastore)
+(sh/alias 'f 'kixi.datastore.filestore)
+(sh/alias 'up 'kixi.datastore.filestore.upload)
+
+(defmethod comms/event-payload
+  [:kixi.datastore.filestore/multi-part-upload-links-created "1.0.0"]
+  [_]
+  (s/keys :req [::up/part-urls
+                ::up/id
+                ::f/id]))
+
+(defmethod comms/event-payload
+  [:kixi.datastore.filestore/multi-part-upload-completed "1.0.0"]
+  [_]
+  (s/keys :req [::up/id
+                ::f/id]))

--- a/src/kixi/datastore/filestore/local.clj
+++ b/src/kixi/datastore/filestore/local.clj
@@ -3,6 +3,8 @@
             [clojure.core.async :as async :refer [go]]
             [com.stuartsierra.component :as component]
             [kixi.datastore.filestore :as fs :refer [FileStore]]
+            [kixi.datastore.filestore.command-handler :as ch]
+            [kixi.comms :as c]
             [taoensso.timbre :as timbre :refer [error info infof]]))
 
 (defn uuid
@@ -14,51 +16,85 @@
   (fn [id]
     (str "file://" dir "/" id)))
 
+(defn remove-file-path-prefix
+  [p]
+  (subs p 7))
+
 (defn file-exists
   [dir id]
-  (let [^java.io.File file (io/file dir
-                                    id)]
+  (let [^java.io.File file (io/file dir id)]
     (.exists file)))
 
 (defn file-size
   [dir id]
-  (when-let [^java.io.File file (io/file dir
-                                         id)]
+  (when-let [^java.io.File file (io/file dir id)]
     (when (.exists file)
       (.length file))))
 
+(defn multi-part-upload-creator
+  [dir]
+  (fn [id part-count]
+    (let [upload-id (uuid)
+          links (vec (doall
+                      (for [i (range 1 (inc part-count))]
+                        (str ((create-link dir) upload-id) "-" i))))]
+      {:upload-id upload-id
+       :upload-part-urls links})))
+
+(defn complete-multi-part-upload-creator
+  [dir]
+  (fn [id etags upload-id]
+    (let [new-file-path (-> ((create-link dir) id)
+                            (remove-file-path-prefix))]
+      (with-open [o (io/output-stream new-file-path)]
+        (run! #(let [path (-> ((create-link dir) upload-id)
+                              (str "-" %)
+                              (remove-file-path-prefix))]
+                 (io/copy (io/file path) o)) (range 1 (inc (count etags))))))))
+
 (defrecord Local
     [communications base-dir ^java.io.File dir]
-    FileStore
-    (exists [this id]
-      (file-exists dir id))
-    (size [this id]
-      (file-size dir id))
-    (retrieve [this id]
-      (let [^java.io.File file (io/file dir
-                                        id)]
-        (when (.exists file)
-          (io/input-stream file))))
-    (create-link [this id file-name]
-      (let [^java.io.File file (io/file dir
-                                        id)]
-        (when (.exists file)
-          (str "file://" (.getPath file)))))
+  FileStore
+  (exists [this id]
+    (file-exists dir id))
+  (size [this id]
+    (file-size dir id))
+  (retrieve [this id]
+    (let [^java.io.File file (io/file dir id)]
+      (when (.exists file)
+        (io/input-stream file))))
+  (create-link [this id file-name]
+    (let [^java.io.File file (io/file dir id)]
+      (when (.exists file)
+        (str "file://" (.getPath file)))))
 
-    component/Lifecycle
-    (start [component]
-      (if-not dir
-        (let [dir (io/file (str (System/getProperty "java.io.tmpdir") base-dir))]
-          (.mkdirs dir)
-          (fs/attach-command-handlers communications
-                                      {:link-creator (create-link dir)})
-          (assoc component :dir dir))
-        component))
-    (stop [component]
-      (info "Destroying Local File Datastore")
-      (if dir
-        (do (doseq [^java.io.File f (.listFiles dir)]
-              (.delete f))
-            (.delete dir)
-            (dissoc component :dir))
-        component)))
+  component/Lifecycle
+  (start [component]
+    (if-not dir
+      (let [dir (io/file (str (System/getProperty "java.io.tmpdir") base-dir))]
+        (.mkdirs dir)
+        (c/attach-command-handler!
+         communications
+         :kixi.datastore/filestore
+         :kixi.datastore.filestore/create-upload-link
+         "1.0.0" (ch/create-upload-cmd-handler (create-link dir)))
+        (c/attach-validating-command-handler!
+         communications
+         :kixi.datastore/filestore-multi-part
+         :kixi.datastore.filestore/create-multi-part-upload-link
+         "1.0.0" (ch/create-multi-part-upload-cmd-handler (multi-part-upload-creator dir)))
+        (c/attach-validating-command-handler!
+         communications
+         :kixi.datastore/filestore-multi-part-completed
+         :kixi.datastore.filestore/complete-multi-part-upload
+         "1.0.0" (ch/create-complete-multi-part-upload-cmd-handler (complete-multi-part-upload-creator dir)))
+        (assoc component :dir dir))
+      component))
+  (stop [component]
+    (info "Destroying Local File Datastore")
+    (if dir
+      (do (doseq [^java.io.File f (.listFiles dir)]
+            (.delete f))
+          (.delete dir)
+          (dissoc component :dir))
+      component)))

--- a/src/kixi/datastore/filestore/s3.clj
+++ b/src/kixi/datastore/filestore/s3.clj
@@ -6,14 +6,41 @@
             [clojure.core.async :as async :refer [go]]
             [com.stuartsierra.component :as component]
             [kixi.datastore.filestore :as fs :refer [FileStore]]
+            [kixi.datastore.filestore.command-handler :as ch]
             [kixi.datastore.time :as t]
+            [kixi.comms :as c]
             [taoensso.timbre :as timbre :refer [error]])
-  (:import [com.amazonaws.services.s3.model AmazonS3Exception]))
+  (:import [com.amazonaws.services.s3.model AmazonS3Exception GeneratePresignedUrlRequest PartETag CompleteMultipartUploadRequest]))
 
 (defn ensure-bucket
   [creds bucket]
   (when-not (s3/does-bucket-exist creds bucket)
     (s3/create-bucket creds bucket)))
+
+(defn multi-part-upload-creator
+  [creds bucket]
+  (fn [id part-count]
+    (let [{:keys [upload-id] :as initate-resp} (s3/initiate-multipart-upload creds
+                                                                             :bucket-name bucket
+                                                                             :key id)
+          client (com.amazonaws.services.s3.AmazonS3ClientBuilder/defaultClient)
+          links (vec (doall
+                      (for [i (range 1 (inc part-count))]
+                        (let [^org.joda.time.DateTime exp (t/minutes-from-now (* 60 24)) ;; 24hrs
+                              req (doto (GeneratePresignedUrlRequest. bucket id com.amazonaws.HttpMethod/PUT)
+                                    (.setExpiration (.toDate exp))
+                                    (.addRequestParameter "partNumber" (str i))
+                                    (.addRequestParameter "uploadId" upload-id))]
+                          (str (.generatePresignedUrl client req))))))]
+      {:upload-id upload-id
+       :upload-part-urls links})))
+
+(defn complete-multi-part-upload-creator
+  [creds bucket]
+  (fn [id etags upload-id]
+    (let [req (CompleteMultipartUploadRequest. bucket id upload-id (map-indexed #(PartETag. (inc %1) %2) etags))
+          client (com.amazonaws.services.s3.AmazonS3ClientBuilder/defaultClient)]
+      (.completeMultipartUpload client req))))
 
 (defn create-link
   [creds bucket]
@@ -56,48 +83,61 @@
 
 (defn create-dload-link
   [creds bucket id file-name expiry]
-  (let [header-overrides (com.amazonaws.services.s3.model.ResponseHeaderOverrides.)
-        _ (when file-name (.setContentDisposition header-overrides (str "attachment; filename=" (sanitize-filename file-name))))]
+  (let [header-overrides (com.amazonaws.services.s3.model.ResponseHeaderOverrides.)]
+    (when file-name
+      (.setContentDisposition header-overrides (str "attachment; filename=" (sanitize-filename file-name))))
     (-> (s3/generate-presigned-url creds
-                                   :bucket-name bucket 
+                                   :bucket-name bucket
                                    :key id
                                    :expiration expiry
-                                   :method "GET" 
+                                   :method "GET"
                                    :response-headers header-overrides)
         str)))
 
 (defrecord S3
     [communications logging region endpoint access-key secret-key link-expiration-mins bucket client-options creds]
-    FileStore
-    (exists [this id]
-      (s3/does-object-exist creds bucket id))
-    (size [this id]
-      (object-size creds bucket id))
-    (retrieve [this id]
-      (when (s3/does-object-exist creds bucket id)
-        (:object-content
-         (s3/get-object creds bucket id))))
-    (create-link [this id file-name]
-      (when (s3/does-object-exist creds bucket id)
-        (create-dload-link creds bucket id file-name
-                           (t/minutes-from-now link-expiration-mins))))
-    component/Lifecycle
-    (start [component]
-      (if-not creds
-        (let [c (merge {:endpoint endpoint}
-                       (when secret-key
-                         {:secret-key secret-key})
-                       (when access-key
-                         {:access-key access-key}))]
-          (ensure-bucket c bucket)
-          (fs/attach-command-handlers communications
-                                      {:link-creator (create-link c bucket)})
-          (assoc component
-                 :creds
-                 c))
-        component))
-    (stop [component]
-      (if creds
-        (dissoc component
-                :creds)
-        component)))
+  FileStore
+  (exists [this id]
+    (s3/does-object-exist creds bucket id))
+  (size [this id]
+    (object-size creds bucket id))
+  (retrieve [this id]
+    (when (s3/does-object-exist creds bucket id)
+      (:object-content (s3/get-object creds bucket id))))
+  (create-link [this id file-name]
+    (when (s3/does-object-exist creds bucket id)
+      (create-dload-link creds bucket id file-name
+                         (t/minutes-from-now link-expiration-mins))))
+  component/Lifecycle
+  (start [component]
+    (if-not creds
+      (let [c (merge {:endpoint endpoint}
+                     (when secret-key
+                       {:secret-key secret-key})
+                     (when access-key
+                       {:access-key access-key}))]
+        (ensure-bucket c bucket)
+        (c/attach-command-handler!
+         communications
+         :kixi.datastore/filestore
+         :kixi.datastore.filestore/create-upload-link
+         "1.0.0" (ch/create-upload-cmd-handler (create-link c bucket)))
+        (c/attach-validating-command-handler!
+         communications
+         :kixi.datastore/filestore-multi-part
+         :kixi.datastore.filestore/create-multi-part-upload-link
+         "1.0.0" (ch/create-multi-part-upload-cmd-handler (multi-part-upload-creator c bucket)))
+        (c/attach-validating-command-handler!
+         communications
+         :kixi.datastore/filestore-multi-part-completed
+         :kixi.datastore.filestore/complete-multi-part-upload
+         "1.0.0" (ch/create-complete-multi-part-upload-cmd-handler (complete-multi-part-upload-creator c bucket)))
+        (assoc component
+               :creds
+               c))
+      component))
+  (stop [component]
+    (if creds
+      (dissoc component
+              :creds)
+      component)))

--- a/src/kixi/datastore/filestore/upload.clj
+++ b/src/kixi/datastore/filestore/upload.clj
@@ -1,0 +1,8 @@
+(ns kixi.datastore.filestore.upload
+  (:require [clojure.spec.alpha :as s]
+            [kixi.datastore.schemastore.conformers :as sc]))
+
+(s/def ::id string?)
+(s/def ::part-count int?)
+(s/def ::part-ids (s/coll-of sc/not-empty-string))
+(s/def ::part-urls (s/coll-of sc/not-empty-string))

--- a/src/kixi/datastore/metadatastore/command_handler.clj
+++ b/src/kixi/datastore/metadatastore/command_handler.clj
@@ -23,7 +23,6 @@
 (sh/alias 'kdm 'kixi.datastore.metadatastore)
 (sh/alias 'kdfm 'kixi.datastore.file-metadata)
 
-
 (sh/alias 'event 'kixi.event)
 
 (defn reject

--- a/src/kixi/datastore/repl.clj
+++ b/src/kixi/datastore/repl.clj
@@ -7,10 +7,10 @@
 (defrecord ReplServer [port]
   component/Lifecycle
   (start [this]
-    (println "Starting REPL server - port " port)
+    (prn "Starting REPL server - port " port)
     (assoc this :repl-server
            (nrepl-server/start-server :handler cider-nrepl-handler :bind "0.0.0.0" :port port)))
   (stop [this]
-    (println "Stopping REPL server")
+    (prn "Stopping REPL server" this)
     (nrepl-server/stop-server (:repl-server this))
     (dissoc this :repl-server)))

--- a/test/kixi/integration/upload_test.clj
+++ b/test/kixi/integration/upload_test.clj
@@ -18,7 +18,7 @@
 
 (deftest round-trip-small-file
   (let [uid (uuid)
-        md-resp (send-file-and-metadata 
+        md-resp (send-file-and-metadata
                  (create-metadata uid
                                   "./test-resources/metadata-one-valid.csv"))]
     (when-success md-resp
@@ -29,7 +29,7 @@
 
 (deftest round-trip-12M-file
   (let [uid (uuid)
-        md-resp (send-file-and-metadata 
+        md-resp (send-file-and-metadata
                  (create-metadata uid
                                   "./test-resources/metadata-12MB-valid.csv"))]
     (when-success md-resp
@@ -38,9 +38,9 @@
              "./test-resources/metadata-12MB-valid.csv"
              (dload-file uid locat)))))))
 
-(deftest round-trip-344M-file  
+(deftest round-trip-344M-file
   (let [uid (uuid)
-        md-resp (send-file-and-metadata 
+        md-resp (send-file-and-metadata
                  (create-metadata uid
                                   "./test-resources/metadata-344MB-valid.csv"))]
     (when-success md-resp
@@ -49,9 +49,20 @@
              "./test-resources/metadata-344MB-valid.csv"
              (dload-file uid locat)))))))
 
+(deftest multi-part-round-trip-12MB-file
+  (let [uid (uuid)
+        md-resp (send-multi-part-file-and-metadata
+                 (create-metadata uid
+                                  "./test-resources/metadata-12MB-valid.csv"))]
+    (when-success md-resp
+      (let [locat (file-url (get-in md-resp [:body ::ms/id]))]
+        (is (files-match?
+             "./test-resources/metadata-12MB-valid.csv"
+             (dload-file uid locat)))))))
+
 (deftest rejected-when-file-not-uploaded
   (let [uid (uuid)]
-    (is-file-metadata-rejected 
+    (is-file-metadata-rejected
      uid
      #(send-metadata-cmd uid
                          (assoc (create-metadata uid
@@ -61,7 +72,7 @@
 
 (deftest rejected-when-size-incorrect
   (let [uid (uuid)]
-    (is-file-metadata-rejected 
+    (is-file-metadata-rejected
      uid
      #(send-file-and-metadata-no-wait
        (assoc (create-metadata uid


### PR DESCRIPTION
In this patch we introduce two new commands - one to begin a
multi-part upload and one to complete it. This will, in time, replace
the existing upload link command.