### PR TITLE
Healthchecks to HTTP from TCP

### DIFF
--- a/deployment/marathon-config.json.template
+++ b/deployment/marathon-config.json.template
@@ -32,7 +32,7 @@
     "cpus": @@CPUS@@,
     "mem": @@MEM@@,
     "healthChecks": [{
-        "protocol": "HTTP",
+        "protocol": "MESOS_HTTP",
         "path": "/healthcheck",
         "gracePeriodSeconds": 600,
         "intervalSeconds": 30,

--- a/deployment/marathon-config.json.template
+++ b/deployment/marathon-config.json.template
@@ -32,7 +32,7 @@
     "cpus": @@CPUS@@,
     "mem": @@MEM@@,
     "healthChecks": [{
-        "protocol": "MESOS_HTTP",
+        "protocol": "HTTP",
         "path": "/healthcheck",
         "gracePeriodSeconds": 600,
         "intervalSeconds": 30,

--- a/deployment/marathon-config.json.template
+++ b/deployment/marathon-config.json.template
@@ -16,7 +16,7 @@
                 {
                     "containerPort": 18080,
                     "hostPort": @@HOST_PORT@@,
-                    "protocol": "tcp"
+                    "protocol": "http"
                 },
                 {
                     "containerPort": 5002,
@@ -32,7 +32,7 @@
     "cpus": @@CPUS@@,
     "mem": @@MEM@@,
     "healthChecks": [{
-        "protocol": "TCP",
+        "protocol": "HTTP",
         "path": "/healthcheck",
         "gracePeriodSeconds": 600,
         "intervalSeconds": 30,

--- a/deployment/marathon-config.json.template
+++ b/deployment/marathon-config.json.template
@@ -16,7 +16,7 @@
                 {
                     "containerPort": 18080,
                     "hostPort": @@HOST_PORT@@,
-                    "protocol": "http"
+                    "protocol": "tcp"
                 },
                 {
                     "containerPort": 5002,

--- a/deployment/production-marathon.json
+++ b/deployment/production-marathon.json
@@ -15,7 +15,7 @@
           {
               "containerPort": 18080,
               "hostPort": 18080,
-              "protocol": "http"
+              "protocol": "tcp"
           },
           {
               "containerPort": 5002,

--- a/deployment/production-marathon.json
+++ b/deployment/production-marathon.json
@@ -15,7 +15,7 @@
           {
               "containerPort": 18080,
               "hostPort": 18080,
-              "protocol": "tcp"
+              "protocol": "http"
           },
           {
               "containerPort": 5002,
@@ -31,7 +31,7 @@
   "cpus": 0.2,
   "mem": 1024,
   "healthChecks": [{
-        "protocol": "TCP",
+        "protocol": "HTTP",
         "path": "/healthcheck",
         "gracePeriodSeconds": 600,
         "intervalSeconds": 30,

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -6,14 +6,11 @@
                    :prod {:region "eu-west-1"
                           :sns  "arn:aws:sns:eu-west-1:720433613167:witan-to-slack"
                           :alerts? true}}
- :web-server #profile {:default {:vhost #or [#env VHOST "localhost"]
-                                 :port  #long #or [#env PORT "8080"]
+ :web-server #profile {:default {:port  #long #or [#env PORT "8080"]
                                  :request-logging? true}
-                       :staging {:vhost "kixi.datastore.marathon.mesos"
-                                 :port 18080
+                       :staging {:port 18080
                                  :request-logging? true}
-                       :prod {:vhost "kixi.datastore.marathon.mesos"
-                              :port 18080
+                       :prod {:port 18080
                               :request-logging? true}}
  :metrics {:json-reporter {:seconds #profile {:staging 60
                                               :prod 60

--- a/src/kixi/datastore/web_server.clj
+++ b/src/kixi/datastore/web_server.clj
@@ -342,16 +342,13 @@
     [true (yada/handler nil)]]])
 
 (defrecord WebServer
-    [port vhost listener log-config metrics filestore metadatastore communications schemastore request-logging?]
+    [port listener log-config metrics filestore metadatastore communications schemastore request-logging?]
   component/Lifecycle
   (start [component]
     (if listener
       component
-      (let [vhosts-model (vhosts-model
-                          [{:scheme :http
-                            :host (str vhost ":" port)}
-                           (routes metrics filestore metadatastore communications schemastore request-logging?)])
-            listener (yada/listener vhosts-model {:port port})]
+      (let [listener (yada/listener (routes metrics filestore metadatastore communications schemastore request-logging?)
+                                    {:port port})]
         (infof "Started web-server on port %s" port)
         (assoc component :listener listener))))
   (stop [component]


### PR DESCRIPTION
This will cause DCOS to actually check the healthcheck path and assert
the web interface is available.