### PR TITLE
Consolidate upload commands into one shiny new one

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,13 +8,13 @@
   :dependencies [[aero "1.1.2"]
                  [aleph "0.4.2-alpha8"]
                  [amazonica "0.3.92" :exclusions [ch.qos.logback/logback-classic
-                                                   com.amazonaws/aws-java-sdk
-                                                   com.fasterxml.jackson.dataformat/jackson-dataformat-cbor
-                                                   commons-logging
-                                                   com.fasterxml.jackson.core/jackson-databind
-                                                   com.fasterxml.jackson.core/jackson-core
-                                                   org.apache.httpcomponents/httpclient
-                                                   joda-time]]
+                                                  com.amazonaws/aws-java-sdk
+                                                  com.fasterxml.jackson.dataformat/jackson-dataformat-cbor
+                                                  commons-logging
+                                                  com.fasterxml.jackson.core/jackson-databind
+                                                  com.fasterxml.jackson.core/jackson-core
+                                                  org.apache.httpcomponents/httpclient
+                                                  joda-time]]
                  [com.amazonaws/aws-java-sdk "1.11.53" :exclusions [joda-time]]
                  [bidi "2.0.12"]
                  [byte-streams "0.2.3"]

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -28,12 +28,19 @@
            :appender #profile {:default :println
                                :staging :json
                                :prod :json}}
+ :filestore-upload-cache #profile {:default {:dynamodb {:endpoint #or [#env DYNAMODB "http://localhost:8000"]}}
+                                   :local-kinesis {:dynamodb {:endpoint #or [#env DYNAMODB "http://localhost:8000"]}}
+                                   :staging-jenkins {:dynamodb {:endpoint "dynamodb.eu-central-1.amazonaws.com"}}
+                                   :staging {:dynamodb {:endpoint "dynamodb.eu-central-1.amazonaws.com"}}
+                                   :prod {:dynamodb {:endpoint "dynamodb.eu-west-1.amazonaws.com"}}}
  :filestore #profile {:default {:local {:base-dir "/kixi-datastore"}
+                                #_:s3 #_{:bucket "staging-witan-kixi-datastore-filestore-jenkins"
+                                         :endpoint "s3.eu-central-1.amazonaws.com"
+                                         :link-expiration-mins 10}
+
                                 #_:local-kinesis #_{:base-dir "/kixi-datastore"}
                                         ;To use S3 locally, remove :local config and set some keys.
-                                #_:s3 #_{:bucket "kixi-data-store-file-store-staging"
-                                         :endpoint "s3.eu-central-1.amazonaws.com"
-                                         :link-expiration-mins 10                                         }}
+                                }
                       :staging-jenkins {:s3 {:bucket "staging-witan-kixi-datastore-filestore-jenkins"
                                              :endpoint "s3.eu-central-1.amazonaws.com"
                                              :link-expiration-mins 10}}

--- a/src/kixi/datastore/filestore.clj
+++ b/src/kixi/datastore/filestore.clj
@@ -6,18 +6,18 @@
             [kixi.comms :as comms]))
 
 (s/def ::id sc/uuid)
-(s/def ::upload-link sc/not-empty-string)
-(s/def ::link sc/not-empty-string)
 
 (defmethod comms/command-type->event-types
-  [:kixi.datastore.filestore/create-multi-part-upload-link "1.0.0"]
+  [:kixi.datastore.filestore/initiate-file-upload "1.0.0"]
   [_]
-  #{[:kixi.datastore.filestore/multi-part-upload-links-created "1.0.0"]})
+  #{[:kixi.datastore.filestore/file-upload-initiated "1.0.0"]})
 
 (defmethod comms/command-type->event-types
-  [:kixi.datastore.filestore/complete-multi-part-upload "1.0.0"]
+  [:kixi.datastore.filestore/complete-file-upload
+   "1.0.0"]
   [_]
-  #{[:kixi.datastore.filestore/multi-part-upload-completed "1.0.0"]})
+  #{[:kixi.datastore.filestore/file-upload-completed "1.0.0"]
+    [:kixi.datastore.filestore/file-upload-rejected "1.0.0"]})
 
 (defprotocol FileStore
   (exists [this id]
@@ -28,3 +28,9 @@
     "Returns an inputstream for read a files contents from")
   (create-link [this id file-name]
     "Returns a link from which the file can be downloaded"))
+
+(defprotocol FileStoreUploadCache
+  (get-item [this file-id]
+    "Gets an item with this upload ID")
+  (put-item! [this file-id mup? user upload-id]
+    "Puts an item into the cache"))

--- a/src/kixi/datastore/filestore/command_handler.clj
+++ b/src/kixi/datastore/filestore/command_handler.clj
@@ -1,14 +1,34 @@
 (ns kixi.datastore.filestore.command-handler
-  (:require [kixi.datastore.schemastore.utils :as sh]))
+  (:require [clojure.spec.alpha :as spec]
+            [medley.core :as m]
+            [taoensso.timbre :as log]
+            [kixi.datastore.schemastore.utils :as sh]
+            [kixi.datastore.filestore :as fs :refer [FileStoreUploadCache]]))
 
 (sh/alias 'event 'kixi.event)
 (sh/alias 'ms 'kixi.datastore.metadatastore)
-(sh/alias 'fs 'kixi.datastore.filestore)
 (sh/alias 'up 'kixi.datastore.filestore.upload)
+(sh/alias 'up-reject 'kixi.event.file.upload.rejection)
 
 (defn uuid
   []
   (str (java.util.UUID/randomUUID)))
+
+(defn calc-chunk-ranges
+  [size-per-part file-size]
+  (let [num-chunks (/ file-size size-per-part)
+        num-major-chunks (Math/floor num-chunks)
+        get-start (fn [x]
+                    (+ (get x :start-byte 0) (get x :length-bytes 0)))
+        chunk-ranges (reduce (fn [a x]
+                               (conj a {:start-byte (get-start (last a))
+                                        :length-bytes size-per-part})) [] (range num-major-chunks))]
+    (conj chunk-ranges {:start-byte (get-start (last chunk-ranges))
+                        :length-bytes (- file-size (* (count chunk-ranges) size-per-part))})))
+
+(defn add-ns
+  [ns m]
+  (m/map-keys (comp (partial keyword (name ns)) name) m))
 
 (defn create-upload-cmd-handler
   [link-fn]
@@ -21,28 +41,60 @@
                                   ::fs/id id
                                   :kixi.user/id (get-in e [:kixi.comms.command/user :kixi.user/id])}})))
 
-(defn create-multi-part-upload-cmd-handler
-  [multi-part-upload-fn]
+(defn reject-file-upload
+  ([file-id reason]
+   (reject-file-upload file-id reason nil))
+  ([file-id reason message]
+   [(merge {::event/type :kixi.datastore.filestore/file-upload-rejected
+            ::event/version "1.0.0"
+            ::up-reject/reason reason
+            ::fs/id file-id}
+           (when message
+             {::up-reject/message message}))
+    {:partition-key file-id}]))
+
+(def small-file-size 10000000) ;; 10MB
+
+(defn create-initiate-file-upload-cmd-handler
+  [init-small-file-upload-creator-fn
+   init-multi-part-file-upload-creator-fn
+   cache]
   (fn [cmd]
-    (let [part-count (::up/part-count cmd)
+    (let [size-bytes (::up/size-bytes cmd)
           id (uuid)
-          {:keys [upload-part-urls upload-id]} (multi-part-upload-fn id part-count)]
-      [{::event/type ::fs/multi-part-upload-links-created
+          part-ranges (calc-chunk-ranges small-file-size size-bytes)
+          mup? (> (count part-ranges) 1)
+          {:keys [upload-parts upload-id]}
+          (if mup?
+            (init-multi-part-file-upload-creator-fn id part-ranges)
+            {:upload-id "local"
+             :upload-parts (update part-ranges 0 assoc :url (init-small-file-upload-creator-fn id))})]
+      (fs/put-item! cache id mup? (:kixi/user cmd) upload-id)
+      [{::event/type ::fs/file-upload-initiated
         ::event/version "1.0.0"
-        ::up/part-urls upload-part-urls
-        ::up/id upload-id
+        ::up/part-urls (m/map-vals (partial add-ns :kixi.datastore.filestore.upload) upload-parts)
         ::fs/id id}
        {:partition-key id}])))
 
-(defn create-complete-multi-part-upload-cmd-handler
-  [complete-multi-part-upload-fn]
+(defn create-complete-file-upload-cmd-handler
+  [complete-small-file-upload-creator-fn
+   complete-multi-part-file-upload-creator-fn
+   cache]
   (fn [cmd]
     (let [{:keys [kixi.datastore.filestore.upload/part-ids
-                  kixi.datastore.filestore/id]} cmd
-          upload-id (:kixi.datastore.filestore.upload/id cmd)]
-      (complete-multi-part-upload-fn id part-ids upload-id)
-      [{::event/type ::fs/multi-part-upload-completed
-        ::event/version "1.0.0"
-        ::up/id upload-id
-        ::fs/id id}
-       {:partition-key id}])))
+                  kixi.datastore.filestore/id
+                  kixi/user]} cmd]
+      (let [upload (not-empty (fs/get-item cache id))]
+        (cond
+          (not (spec/valid? :kixi/command cmd)) (reject-file-upload id :invalid-cmd)
+          (not upload) (reject-file-upload id :unauthorised)
+          (not (= (:kixi.user/id user) (get-in upload [:kixi/user :kixi.user/id]))) (reject-file-upload id :unauthorised)
+          :else (let [[ok? reason msg] (if (::up/mup? upload)
+                                         (complete-multi-part-file-upload-creator-fn id part-ids upload)
+                                         (complete-small-file-upload-creator-fn id part-ids upload))]
+                  (if ok?
+                    [{::event/type ::fs/file-upload-completed
+                      ::event/version "1.0.0"
+                      ::fs/id id}
+                     {:partition-key id}]
+                    (reject-file-upload id reason msg))))))))

--- a/src/kixi/datastore/filestore/commands.clj
+++ b/src/kixi/datastore/filestore/commands.clj
@@ -7,13 +7,12 @@
 (sh/alias 'up 'kixi.datastore.filestore.upload)
 
 (defmethod comms/command-payload
-  [:kixi.datastore.filestore/create-multi-part-upload-link "1.0.0"]
+  [:kixi.datastore.filestore/initiate-file-upload "1.0.0"]
   [_]
-  (s/keys :req [::up/part-count]))
+  (s/keys :req [::up/size-bytes]))
 
 (defmethod comms/command-payload
-  [:kixi.datastore.filestore/complete-multi-part-upload "1.0.0"]
+  [:kixi.datastore.filestore/complete-file-upload "1.0.0"]
   [_]
   (s/keys :req [::up/part-ids
-                ::up/id
                 ::f/id]))

--- a/src/kixi/datastore/filestore/events.clj
+++ b/src/kixi/datastore/filestore/events.clj
@@ -3,19 +3,32 @@
             [kixi.comms :as comms]
             [kixi.datastore.schemastore.utils :as sh]))
 
-(sh/alias 'ms 'kixi.datastore.metadatastore)
-(sh/alias 'f 'kixi.datastore.filestore)
-(sh/alias 'up 'kixi.datastore.filestore.upload)
+(sh/alias 'fs  'kixi.datastore.filestore)
+(sh/alias 'up  'kixi.datastore.filestore.upload)
+(sh/alias 'up-reject 'kixi.event.file.upload.rejection)
 
 (defmethod comms/event-payload
-  [:kixi.datastore.filestore/multi-part-upload-links-created "1.0.0"]
+  [:kixi.datastore.filestore/file-upload-initiated "1.0.0"]
   [_]
   (s/keys :req [::up/part-urls
-                ::up/id
-                ::f/id]))
+                ::fs/id]))
 
 (defmethod comms/event-payload
-  [:kixi.datastore.filestore/multi-part-upload-completed "1.0.0"]
+  [:kixi.datastore.filestore/file-upload-completed "1.0.0"]
   [_]
-  (s/keys :req [::up/id
-                ::f/id]))
+  (s/keys :req [::fs/id]))
+
+(s/def ::up-reject/reason
+  #{:invalid-cmd
+    :file-missing
+    :unauthorised
+    :data-too-small})
+
+(s/def ::up-reject/message string?)
+
+(defmethod comms/event-payload
+  [:kixi.datastore.filestore/file-upload-rejected "1.0.0"]
+  [_]
+  (s/keys :req [::fs/id
+                ::up-reject/reason]
+          :opt [::up-reject/message]))

--- a/src/kixi/datastore/filestore/local.clj
+++ b/src/kixi/datastore/filestore/local.clj
@@ -2,7 +2,7 @@
   (:require [clojure.java.io :as io]
             [clojure.core.async :as async :refer [go]]
             [com.stuartsierra.component :as component]
-            [kixi.datastore.filestore :as fs :refer [FileStore]]
+            [kixi.datastore.filestore :as fs :refer [FileStore FileStoreUploadCache]]
             [kixi.datastore.filestore.command-handler :as ch]
             [kixi.comms :as c]
             [taoensso.timbre :as timbre :refer [error info infof]]))
@@ -20,7 +20,7 @@
   [p]
   (subs p 7))
 
-(defn file-exists
+(defn file-exists?
   [dir id]
   (let [^java.io.File file (io/file dir id)]
     (.exists file)))
@@ -31,32 +31,41 @@
     (when (.exists file)
       (.length file))))
 
-(defn multi-part-upload-creator
+(defn init-multi-part-upload-creator
   [dir]
-  (fn [id part-count]
-    (let [upload-id (uuid)
-          links (vec (doall
-                      (for [i (range 1 (inc part-count))]
-                        (str ((create-link dir) upload-id) "-" i))))]
-      {:upload-id upload-id
-       :upload-part-urls links})))
+  (fn [id part-ranges]
+    (let [links (vec (map-indexed (fn [i p]
+                                    (assoc p :url (str ((create-link dir) id) "-" i))) part-ranges))]
+      {:upload-id (uuid)
+       :upload-parts links})))
 
 (defn complete-multi-part-upload-creator
   [dir]
-  (fn [id etags upload-id]
-    (let [new-file-path (-> ((create-link dir) id)
-                            (remove-file-path-prefix))]
-      (with-open [o (io/output-stream new-file-path)]
-        (run! #(let [path (-> ((create-link dir) upload-id)
-                              (str "-" %)
-                              (remove-file-path-prefix))]
-                 (io/copy (io/file path) o)) (range 1 (inc (count etags))))))))
+  (fn [id etags _]
+    (try (let [new-file-path (-> ((create-link dir) id)
+                                 (remove-file-path-prefix))]
+           (with-open [o (io/output-stream new-file-path)]
+             (run! #(let [path (-> ((create-link dir) id)
+                                   (str "-" %)
+                                   (remove-file-path-prefix))]
+                      (io/copy (io/file path) o)) (range (count etags)))))
+         [true nil nil]
+         (catch java.io.FileNotFoundException _
+           [false :file-missing nil]))))
+
+(defn complete-small-file-upload-creator
+  [dir]
+  (fn [id part-ids _]
+    (if (file-exists? dir id)
+      [true nil nil]
+      [false :file-missing nil])))
 
 (defrecord Local
-    [communications base-dir ^java.io.File dir]
+    [communications filestore-upload-cache base-dir
+     ^java.io.File dir]
   FileStore
   (exists [this id]
-    (file-exists dir id))
+    (file-exists? dir id))
   (size [this id]
     (file-size dir id))
   (retrieve [this id]
@@ -73,22 +82,31 @@
     (if-not dir
       (let [dir (io/file (str (System/getProperty "java.io.tmpdir") base-dir))]
         (.mkdirs dir)
+        ;; LEGACY
         (c/attach-command-handler!
          communications
          :kixi.datastore/filestore
          :kixi.datastore.filestore/create-upload-link
          "1.0.0" (ch/create-upload-cmd-handler (create-link dir)))
+        ;;
         (c/attach-validating-command-handler!
          communications
-         :kixi.datastore/filestore-multi-part
-         :kixi.datastore.filestore/create-multi-part-upload-link
-         "1.0.0" (ch/create-multi-part-upload-cmd-handler (multi-part-upload-creator dir)))
+         :kixi.datastore/filestore-initiate-file-upload
+         :kixi.datastore.filestore/initiate-file-upload
+         "1.0.0" (ch/create-initiate-file-upload-cmd-handler
+                  (create-link dir)
+                  (init-multi-part-upload-creator dir)
+                  filestore-upload-cache))
         (c/attach-validating-command-handler!
          communications
-         :kixi.datastore/filestore-multi-part-completed
-         :kixi.datastore.filestore/complete-multi-part-upload
-         "1.0.0" (ch/create-complete-multi-part-upload-cmd-handler (complete-multi-part-upload-creator dir)))
-        (assoc component :dir dir))
+         :kixi.datastore/filestore-complete-file-upload
+         :kixi.datastore.filestore/complete-file-upload
+         "1.0.0" (ch/create-complete-file-upload-cmd-handler
+                  (complete-small-file-upload-creator dir)
+                  (complete-multi-part-upload-creator dir)
+                  filestore-upload-cache))
+        (assoc component
+               :dir dir))
       component))
   (stop [component]
     (info "Destroying Local File Datastore")

--- a/src/kixi/datastore/filestore/migrators/dynamodb/migrator_20171109_init.clj
+++ b/src/kixi/datastore/filestore/migrators/dynamodb/migrator_20171109_init.clj
@@ -1,0 +1,46 @@
+(ns kixi.datastore.filestore.migrators.dynamodb.migrator-20171109-init
+  (:require [kixi.datastore.system :refer [read-config]]
+            [kixi.datastore.application :refer [profile config-location]]
+            [kixi.datastore.filestore.upload-cache.dynamodb :as fsdb]
+            [kixi.datastore.filestore :as fs]
+            [kixi.datastore.dynamodb :as db]
+            [kixi.datastore.cloudwatch :refer [table-dynamo-alarms]]
+            [taoensso.faraday :as far]
+            [taoensso.timbre :as log]))
+
+(def filestore-upload-write-provision 10)
+(def filestore-upload-read-provision 10)
+
+(defn get-db-config
+  [db]
+  (select-keys db [:endpoint]))
+
+(defn get-alerts-config
+  [profile]
+  (:alerts (read-config @config-location profile)))
+
+(defn up
+  [db]
+  (let [profile (name @profile)
+        conn (get-db-config db)
+        alert-conf (get-alerts-config profile)]
+    (far/create-table conn
+                      (fsdb/primary-upload-cache-table profile)
+                      [(db/dynamo-col ::fs/id) :s]
+                      {:throughput {:read filestore-upload-read-provision
+                                    :write filestore-upload-write-provision}
+                       :block? true})
+    (when (:alerts? alert-conf)
+      (try
+        (table-dynamo-alarms (fsdb/primary-upload-cache-table profile)
+                             (assoc alert-conf
+                                    :read filestore-upload-read-provision
+                                    :write filestore-upload-write-provision))
+        (catch Exception e
+          (log/error e "Failed to create cloudwatch alarm"))))))
+
+(defn down
+  [db]
+  (let [profile (name @profile)
+        conn (get-db-config db)]
+    (far/delete-table conn (fsdb/primary-upload-cache-table profile))))

--- a/src/kixi/datastore/filestore/upload.clj
+++ b/src/kixi/datastore/filestore/upload.clj
@@ -2,7 +2,19 @@
   (:require [clojure.spec.alpha :as s]
             [kixi.datastore.schemastore.conformers :as sc]))
 
-(s/def ::id string?)
 (s/def ::part-count int?)
 (s/def ::part-ids (s/coll-of sc/not-empty-string))
-(s/def ::part-urls (s/coll-of sc/not-empty-string))
+
+(s/def ::start-byte int?)
+(s/def ::length-bytes int?)
+(s/def ::part-url (s/keys :req [::start-byte
+                                ::length-bytes
+                                ::url]))
+(s/def ::part-urls (s/coll-of ::part-url))
+(s/def ::size-bytes int?)
+
+;; db
+(s/def ::id string?)
+(s/def ::mup? boolean?)
+(s/def ::started-at sc/timestamp)
+(s/def ::finished-at sc/timestamp)

--- a/src/kixi/datastore/filestore/upload_cache/dynamodb.clj
+++ b/src/kixi/datastore/filestore/upload_cache/dynamodb.clj
@@ -1,0 +1,54 @@
+(ns kixi.datastore.filestore.upload-cache.dynamodb
+  (:require [com.stuartsierra.component :as component]
+            [taoensso.timbre :as log]
+            [kixi.datastore.time :as t]
+            [kixi.datastore.filestore.upload :as up]
+            [kixi.datastore.filestore :as fs :refer [FileStoreUploadCache]]
+            [kixi.datastore.dynamodb :as db :refer [migrate]]))
+
+(def id-col (db/dynamo-col ::fs/id))
+
+(defn primary-upload-cache-table
+  [profile]
+  (str profile "-kixi.datastore-filestore-upload-cache"))
+
+(defrecord DynamoDb
+    [communications profile
+     client get-item-fn put-item-fn]
+  FileStoreUploadCache
+  (get-item [this file-id]
+    (log/debug "Getting upload item from Dynamo" file-id)
+    (get-item-fn file-id))
+  (put-item! [this file-id mup? user upload-id]
+    (log/debug "Putting upload item into Dynamo" file-id mup?)
+    (put-item-fn {::fs/id file-id
+                  ::up/id upload-id
+                  ::up/mup? mup?
+                  :kixi/user user
+                  ::up/started-at (t/timestamp)
+                  ::up/finished-at nil}))
+  component/Lifecycle
+  (start [component]
+    (if-not client
+      (let [client (assoc (select-keys (:dynamodb component)
+                                       db/client-kws)
+                          :profile profile)
+            joplin-conf {:migrators {:migrator "joplin/kixi/datastore/filestore/migrators/dynamodb"}
+                         :databases {:dynamodb (merge
+                                                {:type :dynamo
+                                                 :migration-table (str profile "-kixi.datastore-filestore.upload.migrations")}
+                                                client)}
+                         :environments {:env [{:db :dynamodb :migrator :migrator}]}}]
+        (log/info "Starting DynamoDb FileStoreUploadCache -" profile)
+        (migrate :env joplin-conf)
+        (assoc component
+               :client client
+               :put-item-fn (partial db/put-item client (primary-upload-cache-table profile))
+               :get-item-fn (partial db/get-item client (primary-upload-cache-table profile) id-col)))
+      component))
+  (stop [component]
+    (if client
+      (do
+        (log/info "Stopping DynamoDb FileStoreUploadCache")
+        (dissoc component :client :get-item-fn :put-item-fn))
+      component)))

--- a/src/kixi/datastore/filestore/upload_cache/inmemory.clj
+++ b/src/kixi/datastore/filestore/upload_cache/inmemory.clj
@@ -1,0 +1,29 @@
+(ns kixi.datastore.filestore.upload-cache.inmemory
+  (:require [com.stuartsierra.component :as component]
+            [kixi.datastore.time :as t]
+            [kixi.datastore.filestore :as fs :refer [FileStoreUploadCache]]
+            [kixi.datastore.filestore.upload :as up]
+            [taoensso.timbre :as log]))
+
+(defrecord InMemory
+    [communications profile endpoint
+     cache]
+  FileStoreUploadCache
+  (get-item [this file-id]
+    (get @cache file-id))
+  (put-item! [this file-id mup? user upload-id]
+    (let [m {::fs/id file-id
+             ::up/id upload-id
+             ::up/mup? mup?
+             :kixi/user user
+             ::up/started-at (t/timestamp)
+             ::up/finished-at nil}]
+      (log/info "Adding" m "for upload" file-id)
+      (swap! cache assoc file-id m)))
+  component/Lifecycle
+  (start [component]
+    (log/info "Starting InMemory FileStoreUploadCache")
+    (assoc component :cache (atom {})))
+  (stop [component]
+    (log/info "Stopping InMemory FileStoreUploadCache")
+    component))

--- a/src/kixi/datastore/system.clj
+++ b/src/kixi/datastore/system.clj
@@ -16,6 +16,9 @@
             [kixi.datastore.filestore
              [local :as local]
              [s3 :as s3]]
+            [kixi.datastore.filestore.upload-cache
+             [inmemory :as fscache-inmemory]
+             [dynamodb :as fscache-dd]]
             [kixi.comms :as comms]
             [kixi.comms.components
              [kinesis :as kinesis]
@@ -50,7 +53,8 @@
    :logging [:metrics]
    :communications []
    :web-server [:metrics :logging :filestore :metadatastore :schemastore :communications]
-   :filestore [:logging :communications]
+   :filestore-upload-cache []
+   :filestore [:logging :communications :filestore-upload-cache]
    :metadatastore [:communications]
    :metadata-creator [:communications :filestore :schemastore :metadatastore]
    :schemastore [:communications]
@@ -72,6 +76,11 @@
            :communications (case (first (keys (:communications config)))
                              :kinesis (kinesis/map->Kinesis {})
                              :coreasync (coreasync/map->CoreAsync {}))}
+          (when (:filestore-upload-cache config)
+            {:filestore-upload-cache
+             (case (first (keys (:filestore-upload-cache config)))
+               :inmemory (fscache-inmemory/map->InMemory {})
+               :dynamodb (fscache-dd/map->DynamoDb {}))})
           (when (:filestore config)
             {:filestore
              (case (first (keys (:filestore config)))

--- a/test/kixi/unit/filestore/command_handler.clj
+++ b/test/kixi/unit/filestore/command_handler.clj
@@ -1,0 +1,29 @@
+(ns kixi.unit.filestore.command-handler
+  (:require [clojure.test :refer :all]
+            [clojure.spec.alpha :as s]
+            [clojure.spec.gen.alpha :as gen]
+            [kixi.datastore.filestore.command-handler :refer :all]))
+
+(deftest calc-chunk-ranges-test
+  (testing "single result"
+    (let [ranges (calc-chunk-ranges 10 9)]
+      (is (= [{:start-byte 0  :length-bytes 9}] ranges))))
+  (testing "small range"
+    (let [ranges (calc-chunk-ranges 10 34)]
+      (is (= [{:start-byte 0  :length-bytes 10}
+              {:start-byte 10 :length-bytes 10}
+              {:start-byte 20 :length-bytes 10}
+              {:start-byte 30 :length-bytes 4}] ranges))))
+  (testing "bigger range"
+    (let [ranges (calc-chunk-ranges 100 648)]
+      (is (= [{:start-byte 0  :length-bytes 100}
+              {:start-byte 100 :length-bytes 100}
+              {:start-byte 200 :length-bytes 100}
+              {:start-byte 300 :length-bytes 100}
+              {:start-byte 400 :length-bytes 100}
+              {:start-byte 500 :length-bytes 100}
+              {:start-byte 600 :length-bytes 48}] ranges)))))
+
+(deftest add-ns-test
+  (let [x (add-ns :foo {:a 1 :b 2 :c {:x 3}})]
+    (is (= {:foo/a 1 :foo/b 2 :foo/c {:x 3}} x))))

--- a/test/kixi/unit/filestore/command_handler.clj
+++ b/test/kixi/unit/filestore/command_handler.clj
@@ -2,27 +2,23 @@
   (:require [clojure.test :refer :all]
             [clojure.spec.alpha :as s]
             [clojure.spec.gen.alpha :as gen]
+            [clojure.spec.test.alpha :as stest]
+            [clojure.test.check :as tc]
             [kixi.datastore.filestore.command-handler :refer :all]))
 
-(deftest calc-chunk-ranges-test
-  (testing "single result"
-    (let [ranges (calc-chunk-ranges 10 9)]
-      (is (= [{:start-byte 0  :length-bytes 9}] ranges))))
-  (testing "small range"
-    (let [ranges (calc-chunk-ranges 10 34)]
-      (is (= [{:start-byte 0  :length-bytes 10}
-              {:start-byte 10 :length-bytes 10}
-              {:start-byte 20 :length-bytes 10}
-              {:start-byte 30 :length-bytes 4}] ranges))))
-  (testing "bigger range"
-    (let [ranges (calc-chunk-ranges 100 648)]
-      (is (= [{:start-byte 0  :length-bytes 100}
-              {:start-byte 100 :length-bytes 100}
-              {:start-byte 200 :length-bytes 100}
-              {:start-byte 300 :length-bytes 100}
-              {:start-byte 400 :length-bytes 100}
-              {:start-byte 500 :length-bytes 100}
-              {:start-byte 600 :length-bytes 48}] ranges)))))
+(def sample-size 100)
+
+(defn check
+  [sym]
+  (-> sym
+      (stest/check {:clojure.spec.test.alpha.check/opts {:num-tests sample-size}})
+      first
+      stest/abbrev-result
+      :failure))
+
+(deftest check-calc-chunk-ranges
+  (is (nil?
+       (check `calc-chunk-ranges))))
 
 (deftest add-ns-test
   (let [x (add-ns :foo {:a 1 :b 2 :c {:x 3}})]


### PR DESCRIPTION
A few changes
* New commands: `initiate-file-upload` and `complete-file-upload`
* New events: `file-upload-initiated`, `file-upload-completed` and `file-upload-rejected`
* Uploads can now only be completed by the user who initiated the upload (otherwise `unauthorised`).
* "Upload IDs" are gone - we only need/use file IDs.

The purpose of the consolidation is to avoid having two separate processes for upload. Previously, once the user had established whether their file is greater-than the minimum size for a multipart upload they would use two entirely separate exchanges. Now there is just one; the juggling of mpu-or-not is handled entirely by the Datastore. This costs us a bit of state which is now handled by DynamoDB. 