### PR TITLE
Upgrading to partition key forcing kixi.comms

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -33,7 +33,7 @@
                  [com.taoensso/encore "2.92.0"]
                  [digest "1.4.6"]
                  [environ "1.1.0"]
-                 [kixi/kixi.comms "0.2.25"]
+                 [kixi/kixi.comms "0.2.27"]
                  [kixi/kixi.log "0.1.4"]
                  [kixi/kixi.metrics "0.4.1"]
                  [kixi/joplin.core "0.3.10-SNAPSHOT"]

--- a/src/kixi/datastore/metadatastore/command_handler.clj
+++ b/src/kixi/datastore/metadatastore/command_handler.clj
@@ -79,7 +79,8 @@
    ::ke/version "1.0.0"
    ::ke/payload payload
    ::ke/partition-key (or (::ms/id payload)
-                          (get-in payload [:original ::ms/id]))})
+                          (get-in payload [:original ::ms/id])
+                          (get-in payload [:original ::ms/payload ::kc/payload ::ms/id]))})
 
 (defn invalid
   ([cmd speccy data]
@@ -100,7 +101,8 @@
   [payload]
   {::ke/key ::kdfm/updated
    ::ke/version "1.0.0"
-   ::ke/partition-key (::ms/id payload)
+   ::ke/partition-key (or (get-in payload [::ms/id])
+                          (get-in payload [::ms/file-metadata ::ms/id]))
    ::ke/payload payload})
 
 (defn get-user-groups
@@ -141,7 +143,8 @@
            (not (ss/authorised schemastore ::ss/use schema-id user-groups))) (reject metadata :unauthorised)
       :default [{::ke/key :kixi.datastore.file/created
                  ::ke/version "1.0.0"
-                 ::ke/payload metadata}
+                 ::ke/payload metadata
+                 ::ke/partition-key id}
                 (updated {::ms/file-metadata metadata
                           ::cs/file-metadata-update-type
                           ::cs/file-metadata-created})])))

--- a/src/kixi/datastore/structural_validation.clj
+++ b/src/kixi/datastore/structural_validation.clj
@@ -67,7 +67,8 @@
              :kixi.comms.event/version "1.0.0"
              :kixi.comms.event/payload {::cs/file-metadata-update-type ::cs/file-metadata-structural-validation-checked
                                         ::ms/id (::ms/id metadata)
-                                        ::ms/structural-validation result}})
+                                        ::ms/structural-validation result}
+             :kixi.comms.event/partition-key (::ms/id metadata)})
           (finally
             (.delete file)))))))
 

--- a/test/kixi/integration/base.clj
+++ b/test/kixi/integration/base.clj
@@ -371,7 +371,7 @@
     "1.0.0"
     {:kixi.user/id uid
      :kixi.user/groups (vec-if-not ugroup)}
-    {})))
+    {:kixi.comms.command/partition-key uid})))
 
 (defn trim-file-name
   [md]
@@ -391,7 +391,8 @@
     "1.0.0"
     {:kixi.user/id uid
      :kixi.user/groups (vec-if-not ugroup)}
-    (trim-file-name metadata))))
+    (trim-file-name metadata)
+    {:kixi.comms.command/partition-key uid})))
 
 (defn send-bundle-delete-cmd
   ([uid meta-id]
@@ -447,7 +448,8 @@
     "1.0.0"
     {:kixi.user/id uid
      :kixi.user/groups (vec-if-not ugroup)}
-    (trim-file-name metadata))))
+    (trim-file-name metadata)
+    {:kixi.comms.command/partition-key uid})))
 
 (defn send-metadata-sharing-change-cmd
   ([uid metadata-id change-type activity target-group]
@@ -462,7 +464,8 @@
     {::ms/id metadata-id
      ::ms/sharing-update change-type
      ::ms/activity activity
-     :kixi.group/id target-group})))
+     :kixi.group/id target-group}
+    {:kixi.comms.command/partition-key uid})))
 
 (defn send-metadata-update-cmd
   ([uid metadata-id new-metadata]
@@ -475,7 +478,8 @@
     {:kixi.user/id uid
      :kixi.user/groups (vec-if-not ugroup)}
     (assoc new-metadata
-           ::ms/id metadata-id))))
+           ::ms/id metadata-id)
+    {:kixi.comms.command/partition-key metadata-id})))
 
 (defn send-update-event
   [uid ugroup event]


### PR DESCRIPTION
Certain handlers weren't providing their partition keys. The new
kixi.comms versions forces even the older event format to explicitly
provide the partition key.

This change moves up to that version and corrects the misbehaving handlers.