### PR TITLE
Add `failed` event when a bad command comes through for `initiate-file-upload`

### DIFF
--- a/src/kixi/datastore/filestore.clj
+++ b/src/kixi/datastore/filestore.clj
@@ -10,7 +10,8 @@
 (defmethod comms/command-type->event-types
   [:kixi.datastore.filestore/initiate-file-upload "1.0.0"]
   [_]
-  #{[:kixi.datastore.filestore/file-upload-initiated "1.0.0"]})
+  #{[:kixi.datastore.filestore/file-upload-initiated "1.0.0"]
+    [:kixi.datastore.filestore/file-upload-failed "1.0.0"]})
 
 (defmethod comms/command-type->event-types
   [:kixi.datastore.filestore/complete-file-upload

--- a/src/kixi/datastore/filestore/events.clj
+++ b/src/kixi/datastore/filestore/events.clj
@@ -5,7 +5,20 @@
 
 (sh/alias 'fs  'kixi.datastore.filestore)
 (sh/alias 'up  'kixi.datastore.filestore.upload)
+(sh/alias 'up-fail 'kixi.event.file.upload.failure)
 (sh/alias 'up-reject 'kixi.event.file.upload.rejection)
+
+(s/def ::up-fail/reason
+  #{:invalid-cmd})
+
+(s/def ::up-reject/reason
+  #{:invalid-cmd
+    :file-missing
+    :unauthorised
+    :data-too-small})
+
+(s/def ::up-fail/message string?)
+(s/def ::up-reject/message string?)
 
 (defmethod comms/event-payload
   [:kixi.datastore.filestore/file-upload-initiated "1.0.0"]
@@ -18,17 +31,15 @@
   [_]
   (s/keys :req [::fs/id]))
 
-(s/def ::up-reject/reason
-  #{:invalid-cmd
-    :file-missing
-    :unauthorised
-    :data-too-small})
-
-(s/def ::up-reject/message string?)
-
 (defmethod comms/event-payload
   [:kixi.datastore.filestore/file-upload-rejected "1.0.0"]
   [_]
   (s/keys :req [::fs/id
                 ::up-reject/reason]
           :opt [::up-reject/message]))
+
+(defmethod comms/event-payload
+  [:kixi.datastore.filestore/file-upload-failed "1.0.0"]
+  [_]
+  (s/keys :req [::up-fail/reason]
+          :opt [::up-fail/message]))

--- a/test/kixi/integration/base.clj
+++ b/test/kixi/integration/base.clj
@@ -535,6 +535,18 @@
      ::fs/id file-id}
     {:partition-key file-id})))
 
+(defn send-bad-multi-part-upload-cmd
+  ([uid]
+   (send-bad-multi-part-upload-cmd uid uid))
+  ([uid ugroup]
+   (c/send-valid-command!
+    @comms
+    {::cmd/type :kixi.datastore.filestore/initiate-file-upload
+     ::cmd/version "1.0.0"
+     :kixi/user {:kixi.user/id uid
+                 :kixi.user/groups (vec-if-not ugroup)}}
+    {:partition-key uid})))
+
 (defn event-for
   [uid event]
   (= uid

--- a/test/kixi/integration/base.clj
+++ b/test/kixi/integration/base.clj
@@ -535,7 +535,8 @@
      ::fs/id file-id}
     {:partition-key file-id})))
 
-(defn send-bad-multi-part-upload-cmd
+(defn send-malformed-multi-part-upload-cmd
+  "This command misses the required `size-bytes` filed which should trigger a failed event"
   ([uid]
    (send-bad-multi-part-upload-cmd uid uid))
   ([uid ugroup]

--- a/test/kixi/integration/base.clj
+++ b/test/kixi/integration/base.clj
@@ -538,7 +538,7 @@
 (defn send-malformed-multi-part-upload-cmd
   "This command misses the required `size-bytes` filed which should trigger a failed event"
   ([uid]
-   (send-bad-multi-part-upload-cmd uid uid))
+   (send-malformed-multi-part-upload-cmd uid uid))
   ([uid ugroup]
    (c/send-valid-command!
     @comms

--- a/test/kixi/integration/upload_test.clj
+++ b/test/kixi/integration/upload_test.clj
@@ -147,7 +147,7 @@
   (let [uid (uuid)
         _ (with-redefs
             [clojure.spec.alpha/valid? (constantly true)]
-            (send-bad-multi-part-upload-cmd uid))
+            (send-malformed-multi-part-upload-cmd uid))
         x (wait-for-events uid :kixi.datastore.filestore/file-upload-failed)]
     (is-submap {:kixi.event/type :kixi.datastore.filestore/file-upload-failed
                 :kixi.event.file.upload.failure/reason :invalid-cmd} x)))

--- a/test/kixi/integration/upload_test.clj
+++ b/test/kixi/integration/upload_test.clj
@@ -142,3 +142,12 @@
         x (wait-for-events uid2 :kixi.datastore.filestore/file-upload-rejected)]
     (is-submap {:kixi.event/type :kixi.datastore.filestore/file-upload-rejected
                 :kixi.event.file.upload.rejection/reason :unauthorised} x)))
+
+(deftest new-file-failed
+  (let [uid (uuid)
+        _ (with-redefs
+            [clojure.spec.alpha/valid? (constantly true)]
+            (send-bad-multi-part-upload-cmd uid))
+        x (wait-for-events uid :kixi.datastore.filestore/file-upload-failed)]
+    (is-submap {:kixi.event/type :kixi.datastore.filestore/file-upload-failed
+                :kixi.event.file.upload.failure/reason :invalid-cmd} x)))


### PR DESCRIPTION
**Every** command should have a corresponding 'failed to validate' event.