### PR TITLE
Moving mup cache to command handler

### DIFF
--- a/src/kixi/datastore/filestore/event_handler.clj
+++ b/src/kixi/datastore/filestore/event_handler.clj
@@ -8,13 +8,6 @@
 
 (sh/alias 'up 'kixi.datastore.filestore.upload)
 
-(defn create-file-upload-initiated-event-handler
-  [cache]
-  (fn [{:keys [::up/part-urls ::fs/id kixi/user kixi.event/created-at] :as event}]
-    (let [upload-id (::up/id event)
-          mup?  (> (count part-urls) 1)]
-      (fs/put-item! cache id mup? user upload-id created-at)
-      nil)))
 
 (defn create-file-upload-completed-event-handler
   [cache]

--- a/src/kixi/datastore/filestore/local.clj
+++ b/src/kixi/datastore/filestore/local.clj
@@ -109,12 +109,6 @@
                   filestore-upload-cache))
         (c/attach-validating-event-handler!
          communications
-         :kixi.datastore/filestore-file-upload-initiated
-         :kixi.datastore.filestore/file-upload-initiated
-         "1.0.0" (eh/create-file-upload-initiated-event-handler
-                  filestore-upload-cache))
-        (c/attach-validating-event-handler!
-         communications
          :kixi.datastore/filestore-file-upload-completed
          :kixi.datastore.filestore/file-upload-completed
          "1.0.0" (eh/create-file-upload-completed-event-handler

--- a/src/kixi/datastore/filestore/s3.clj
+++ b/src/kixi/datastore/filestore/s3.clj
@@ -19,6 +19,7 @@
   (when-not (s3/does-bucket-exist creds bucket)
     (s3/create-bucket creds bucket)))
 
+
 (defn init-multi-part-upload-creator
   [creds bucket]
   (fn [id part-ranges]
@@ -160,12 +161,6 @@
          "1.0.0" (ch/create-complete-file-upload-cmd-handler
                   (complete-small-file-upload-creator c bucket)
                   (complete-multi-part-upload-creator c bucket)
-                  filestore-upload-cache))
-        (c/attach-validating-event-handler!
-         communications
-         :kixi.datastore/filestore-file-upload-initiated
-         :kixi.datastore.filestore/file-upload-initiated
-         "1.0.0" (eh/create-file-upload-initiated-event-handler
                   filestore-upload-cache))
         (c/attach-validating-event-handler!
          communications

--- a/test/kixi/integration/base.clj
+++ b/test/kixi/integration/base.clj
@@ -730,11 +730,11 @@
                         (.read reader buffer 0 length-bytes)
                         (upload-multi-part-file-request url buffer)))
         send-complete (fn [etags]
-                        (wait-for-pred
-                         #(do
-                            (send-complete-multi-part-upload-cmd uid etags file-id)
-                            (let [e (wait-for-events uid :kixi.datastore.filestore/file-upload-completed :kixi.datastore.filestore/file-upload-rejected)]
-                              (= (:kixi.event/type e) :kixi.datastore.filestore/file-upload-completed)))))]
+                        (send-complete-multi-part-upload-cmd uid etags file-id)
+                        (let [e (wait-for-events uid :kixi.datastore.filestore/file-upload-completed
+                                                 :kixi.datastore.filestore/file-upload-rejected)]
+                          (is (= :kixi.datastore.filestore/file-upload-completed
+                                 (:kixi.event/type e)))))]
     (log/info "Uploading file" file-name file-id "in" (count links) "parts." )
     (with-open [r (io/input-stream file)]
       (->> links


### PR DESCRIPTION
Currently the multi part upload cache is written to when an initate
upload event is consumed by an event handler. This is occuring too late
for quick uploads and they are being failed due to the line not having
been written yet.

This change writes to the mup cache when the command is deemed
successful, therefore the line will already be present before the
upload can possibly be completed.