### PR TITLE
ON HOLD Add the ability to filter results from queries

### DIFF
--- a/src/kixi/datastore/kaylee.clj
+++ b/src/kixi/datastore/kaylee.clj
@@ -41,7 +41,8 @@
             from-dex
             page-count
             [::ms/provenance ::ms/created]
-            "desc"))
+            "desc"
+            nil))
 
 (defn send-sharing-update
   "Issues an event with sharing matrix changes, bypasses the command level user authorization."
@@ -50,7 +51,7 @@
   (c/send-event!
    (comms)
    :kixi.datastore.file-metadata/updated
-   "1.0.0"   
+   "1.0.0"
    {::cs/file-metadata-update-type ::cs/file-metadata-sharing-updated
     ::ms/id metadata-id
     ::ms/sharing-update change-type

--- a/src/kixi/datastore/metadatastore.clj
+++ b/src/kixi/datastore/metadatastore.clj
@@ -158,7 +158,7 @@
   (exists [this id])
   (retrieve [this id])
   (create-link [this id])
-  (query [this criteria from-index count sort-by sort-order]))
+  (query [this criteria from-index count sort-by sort-order filters]))
 
 (s/def ::metadatastore
   (let [ex #(ex-info "Use stubbed fn version." {:fn %})]
@@ -169,7 +169,7 @@
                      (exists [this id] (throw (ex "exists")))
                      (retrieve [this id] (throw (ex "retrieve")))
                      (create-link [this id] (throw (ex "link")))
-                     (query [this criteria from-index count sort-by sort-order] (throw (ex "query"))))))))
+                     (query [this criteria from-index count sort-by sort-order filters] (throw (ex "query"))))))))
 
 (s/fdef authorised-fn
         :args (s/cat :impl ::metadatastore

--- a/src/kixi/datastore/metadatastore/inmemory.clj
+++ b/src/kixi/datastore/metadatastore/inmemory.clj
@@ -64,7 +64,7 @@
        id))
     (retrieve [this id]
       (get @data id))
-    (query [this criteria from-index count sort-by sort-order])
+    (query [this criteria from-index count sort-by sort-order filters])
 
     component/Lifecycle
     (start [component]

--- a/test/kixi/integration/base.clj
+++ b/test/kixi/integration/base.clj
@@ -278,15 +278,24 @@
   ([group-ids activities index count]
    (search-metadata group-ids activities index count nil))
   ([group-ids activities index count order]
+   (search-metadata group-ids activities index count order nil))
+  ([group-ids activities index count order filters]
    (client/get (metadata-query-url)
-               {:query-params (merge (zipmap (repeat :activity)
-                                             (map encode-kw activities))
-                                     (when index
-                                       {:index index})
-                                     (when count
-                                       {:count count})
-                                     (when order
-                                       {:sort-order order}))
+               {:query-params
+                (merge (zipmap (repeat :activity)
+                               (map encode-kw activities))
+                       (when index
+                         {:index index})
+                       (when count
+                         {:count count})
+                       (when order
+                         {:sort-order order})
+                       (when filters
+                         {:filter
+                          (reduce (fn [a i]
+                                    (update a i encode-kw))
+                                  filters
+                                  (take-nth 2 (range (clojure.core/count filters))))}))
                 :accept :transit+json
                 :as :transit+json
                 :throw-exceptions false

--- a/test/kixi/integration/search/filter_test.clj
+++ b/test/kixi/integration/search/filter_test.clj
@@ -1,0 +1,42 @@
+(ns kixi.integration.search.filter-test
+  {:integration true}
+  (:require [clojure.test :refer :all]
+            [clojure.math.combinatorics :as combo :refer [subsets]]
+            [kixi.datastore
+             [metadatastore :as ms]
+             [web-server :as ws]]
+            [kixi.integration.base :as base :refer :all :exclude [create-metadata]]))
+
+(alias 'ms 'kixi.datastore.metadatastore)
+
+(defn create-metadata
+  [uid]
+  (base/create-metadata uid "./test-resources/metadata-one-valid.csv"))
+
+(use-fixtures :once
+  cycle-system-fixture
+  extract-comms)
+
+(deftest only-returns-csvs
+  (let [total-files 10
+        uid (uuid)
+        metadata (create-metadata uid)]
+    (->> (range total-files)
+         (map (fn [i]
+                (send-file-and-metadata-no-wait (if (odd? i)
+                                                  (assoc metadata ::ms/file-type "pdf")
+                                                  metadata))))
+         doall
+         (map ::ms/id)
+         (map #(wait-for-metadata-key uid % ::ms/id))
+         doall)
+    (is-submap {:paging {:total total-files
+                         :count total-files
+                         :index 0}}
+               (:body
+                (search-metadata uid [::ms/file-read])))
+    (is-submap {:paging {:total (/ total-files 2)
+                         :count (/ total-files 2)
+                         :index 0}}
+               (:body
+                (search-metadata uid [::ms/file-read] nil nil nil [::ms/file-type "csv"])))))

--- a/test/kixi/unit/dynamodb_test.clj
+++ b/test/kixi/unit/dynamodb_test.clj
@@ -156,3 +156,11 @@
                                          :acc {:acca 1}}}
                                 :b {:ba 2}
                                 :c 3}))))
+
+(deftest local-projection-test
+  (let [nm {:a 1 :b {:x {:z 6 :k 7} :y 5} :c 3 :d 4}]
+    (is (= {:a 1 :c 3}           (db/local-projection [:a :c] nm)))
+    (is (= {:a 1}                (db/local-projection [:a :x] nm)))
+    (is (= {:a 1 :b {:x {:z 6 :k 7} :y 5}} (db/local-projection [:a :b] nm)))
+    (is (= {:a 1 :b {:x {:z 6 :k 7}}}      (db/local-projection [:a [:b :x]] nm)))
+    (is (= {:a 1 :b {:x {:z 6}}}           (db/local-projection [:a [:b :x :z]] nm)))))


### PR DESCRIPTION
Until now the filtering of results based on their metadata type (files
or datapacks) has been done at the frontend. However, this was no longer
possible once we introduced paging and so the functionality has been
pushed onto the datastore. Unfortunately, for this query in
particular (metadata-with-activities) the desired metadata is not
present in the activities table, which means further work will need to
be done before UI paging works. This PR lays the ground work for the
concept of filtering in queries, however, using DynamoDB's 'filter
expressions'.