### PR TITLE
Downgrading some tests to acceptance

### DIFF
--- a/test/kixi/integration/datapack_update_test.clj
+++ b/test/kixi/integration/datapack_update_test.clj
@@ -83,13 +83,13 @@
                          (is (= 401
                                 (:status (get-metadata uid meta-id)))))))))
 
-(deftest deleted-bundles-are-not-returned-in-searches
+(deftest ^:acceptance deleted-bundles-are-not-returned-in-searches
   (let [uid (uuid)
         datapack-resp (small-file-into-datapack uid)]
     (when-success datapack-resp
       (let [meta-id (get-in datapack-resp [:body ::ms/id])
             all-visible-cnt (get-in (search-metadata uid [::ms/meta-read])
-                                [:body :paging :count])]
+                                    [:body :paging :count])]
         (is (= 2
                all-visible-cnt))
         (let [response-event (send-bundle-delete uid meta-id)]
@@ -126,7 +126,7 @@
                                 (:status (get-metadata uid file-meta-id)))))))))
 
 
-(deftest add-files-to-bundle-incorrect-type-rejected
+(deftest ^:acceptance add-files-to-bundle-incorrect-type-rejected
   (let [uid (uuid)
         datapack-resp (small-file-into-datapack uid)]
     (when-success datapack-resp
@@ -169,7 +169,7 @@
 
 
 
-(deftest remove-files-from-bundle-incorrect-type-rejected
+(deftest ^:acceptance remove-files-from-bundle-incorrect-type-rejected
   (let [uid (uuid)
         datapack-resp (small-file-into-datapack uid)]
     (when-success datapack-resp
@@ -179,7 +179,7 @@
                          (is (= :incorrect-type
                                 (:reason response-event))))))))
 
-(deftest remove-files-to-bundle-unauthorised-rejected
+(deftest ^:acceptance remove-files-to-bundle-unauthorised-rejected
   (let [uid (uuid)
         datapack-resp (small-file-into-datapack uid)]
     (when-success datapack-resp

--- a/test/kixi/integration/metadata_test.clj
+++ b/test/kixi/integration/metadata_test.clj
@@ -31,14 +31,14 @@
         sr (get-metadata uid "foo")]
     (unauthorised sr)))
 
-(deftest small-file
+(deftest ^:acceptance small-file
   (let [uid (uuid)
-        schema-id (get-schema-id uid)        
+        schema-id (get-schema-id uid)
         metadata-response (send-file-and-metadata
                            (create-metadata
                             uid
-                            "./test-resources/metadata-one-valid.csv" 
-                           schema-id))]
+                            "./test-resources/metadata-one-valid.csv"
+                            schema-id))]
     (when-success metadata-response
       (let [metadata-response (wait-for-metadata-key uid (extract-id metadata-response) ::ms/structural-validation)]
         (is-submap
@@ -75,13 +75,13 @@
                                 ::ms/source "upload"}}}
        metadata-response))))
 
-(deftest small-file-no-schema-empty-description
+(deftest ^:acceptance small-file-no-schema-empty-description
   (let [uid (uuid)
         metadata-response (send-file-and-metadata
                            (assoc
                             (create-metadata
-                                   uid
-                                   "./test-resources/metadata-one-valid.csv")
+                             uid
+                             "./test-resources/metadata-one-valid.csv")
                             ::ms/description ""))]
     (when-success metadata-response
       (is-submap
@@ -118,7 +118,7 @@
                                 ::ms/source "upload"}}}
        metadata-response))))
 
-(deftest small-file-no-header
+(deftest ^:acceptance small-file-no-header
   (let [uid (uuid)
         schema-id (get-schema-id uid)
         metadata-response (send-file-and-metadata
@@ -144,7 +144,7 @@
                  ::ms/structural-validation {::ms/valid true}}}
          metadata-response)))))
 
-(deftest small-file-invalid-schema
+(deftest ^:acceptance small-file-invalid-schema
   (let [uid (uuid)]
     (is-file-metadata-rejected
      uid

--- a/test/kixi/integration/metadata_update_test.clj
+++ b/test/kixi/integration/metadata_update_test.clj
@@ -172,7 +172,7 @@
                                             (is (nil?
                                                    (get-in updated-metadata [:body ::ms/source-created])))))))))))
 
-(deftest remove-on-nonexistant-field-allowed
+(deftest ^:acceptance remove-on-nonexistant-field-allowed
   (let [uid (uuid)
         metadata-response (send-file-and-metadata
                            (create-metadata
@@ -189,9 +189,9 @@
                                           (not (get-in metadata [:body ::ms/source-created]))))
                         (let [updated-metadata (get-metadata uid meta-id)]
                           (is (nil?
-                                 (get-in updated-metadata [:body ::ms/source-created])))))))))
+                               (get-in updated-metadata [:body ::ms/source-created])))))))))
 
-(deftest small-file-add-invalid-metadata
+(deftest ^:acceptance small-file-add-invalid-metadata
   (let [uid (uuid)
         metadata-response (send-file-and-metadata
                            (create-metadata
@@ -204,7 +204,7 @@
                    {::ms/file-type "Invalid has no command"})]
         (when-event-key event :kixi.datastore.metadatastore/update-rejected
                         (is (= :invalid
-                              (get-in event [:kixi.comms.event/payload :reason]))))))))
+                               (get-in event [:kixi.comms.event/payload :reason]))))))))
 
 (deftest small-file-update-tags
   (let [uid (uuid)
@@ -266,7 +266,7 @@
                                             (is (= #{"orig2" "Tag2" "Tag3"}
                                                    (get-in updated-metadata [:body ::ms/tags])))))))))))
 
-(deftest small-file-update-license-type
+(deftest ^:acceptance small-file-update-license-type
   (let [uid (uuid)
         metadata-response (send-file-and-metadata
                            (assoc (create-metadata
@@ -287,7 +287,7 @@
                           (is (= "new type"
                                  (get-in metadata [:body ::msl/license ::msl/type])))))))))
 
-(deftest small-file-remove-license-type
+(deftest ^:acceptance small-file-remove-license-type
   (let [uid (uuid)
         metadata-response (send-file-and-metadata
                            (assoc (create-metadata
@@ -317,7 +317,7 @@
                          (is (= 401
                                 (:status (get-metadata uid meta-id)))))))))
 
-(deftest deleted-files-are-not-returned-in-searches
+(deftest ^:acceptance deleted-files-are-not-returned-in-searches
   (let [uid (uuid)
         metadata-resp (send-file-and-metadata (create-metadata uid "./test-resources/metadata-one-valid.csv"))]
     (when-success metadata-resp
@@ -335,7 +335,7 @@
                              (is (= 0
                                     only-file-visible-cnt)))))))))
 
-(deftest file-delete-unauthorised-rejected
+(deftest ^:acceptance file-delete-unauthorised-rejected
   (let [uid (uuid)
         metadata-resp (send-file-and-metadata (create-metadata uid "./test-resources/metadata-one-valid.csv"))]
     (when-success metadata-resp
@@ -347,7 +347,7 @@
                          (is (= 200
                                 (:status (get-metadata uid meta-id)))))))))
 
-(deftest file-delete-incorrect-type-rejected
+(deftest ^:acceptance file-delete-incorrect-type-rejected
   (let [uid (uuid)
         datapack-resp (small-file-into-datapack uid)]
     (when datapack-resp

--- a/test/kixi/integration/schema.clj
+++ b/test/kixi/integration/schema.clj
@@ -1,5 +1,5 @@
 (ns kixi.integration.schema
-  {:integration true}
+  {::acceptance true}
   (:require [clojure.spec.test.alpha :refer [with-instrument-disabled]]
             [clojure.test :refer :all]
             [kixi.datastore

--- a/test/kixi/integration/sharing_test.clj
+++ b/test/kixi/integration/sharing_test.clj
@@ -1,4 +1,5 @@
 (ns kixi.integration.sharing-test
+  {:acceptance true}
   (:require [clojure.test :refer :all]
             [clojure.math.combinatorics :as combo :refer [subsets]]
             [environ.core :refer [env]]

--- a/test/kixi/integration/spec_test.clj
+++ b/test/kixi/integration/spec_test.clj
@@ -1,5 +1,5 @@
 (ns kixi.integration.spec-test
-  {:integration true}
+  {:acceptance true}
   (:require [clojure.test :refer :all]
             [kixi.datastore
              [schemastore :as ss]
@@ -38,7 +38,7 @@
 (deftest good-spec-202
   (let [uid (uuid)]
     (success
-     (send-spec uid 
+     (send-spec uid
                 {::ss/name ::good-spec-a
                  ::ss/provenance {::ss/source "upload"
                                   :kixi.user/id uid}


### PR DESCRIPTION
Our test runs againsts staging are taking too long, so we're down
grading a bunch of integration tests to acceptance test, so they are
only run locally.

Generally the tests downgraded are the failure scenarios and close to
over lapping tests.