### PR TITLE
Add TTL to rows in upload cache table

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -17,7 +17,7 @@
        (reset! app/profile (keyword (env :system-profile profile)))
        (reset! app/config-location config-location)
        (try
-         (prn "Starting system")
+         (println "Starting system" profile)
          (->> (system/new-system config-location (keyword (env :system-profile profile)))
               (#(merge % overrides))
               (#(if component-subset
@@ -32,7 +32,7 @@
 (defn stop
   []
   (when @app/system
-    (prn "Stopping system")
+    (println "Stopping system")
     (component/stop-system @app/system)
     (reset! app/system nil)))
 

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[aero "1.1.2"]
                  [aleph "0.4.2-alpha8"]
-                 [amazonica "0.3.92" :exclusions [ch.qos.logback/logback-classic
+                 [amazonica "0.3.93" :exclusions [ch.qos.logback/logback-classic
                                                   com.amazonaws/aws-java-sdk
                                                   com.fasterxml.jackson.dataformat/jackson-dataformat-cbor
                                                   commons-logging
@@ -15,7 +15,10 @@
                                                   com.fasterxml.jackson.core/jackson-core
                                                   org.apache.httpcomponents/httpclient
                                                   joda-time]]
-                 [com.amazonaws/aws-java-sdk "1.11.53" :exclusions [joda-time]]
+                 [com.amazonaws/aws-java-sdk "1.11.253" :exclusions [joda-time
+                                                                     commons-logging
+                                                                     cheshire
+                                                                     com.amazonaws/aws-java-sdk-kinesisvideo]]
                  [bidi "2.0.12"]
                  [byte-streams "0.2.3"]
                  [clj-http "3.7.0"]
@@ -25,20 +28,20 @@
                  [cider/cider-nrepl "0.15.1"]
                  [com.cognitect/transit-clj "0.8.300"]
                  [com.fzakaria/slf4j-timbre "0.3.7"]
+                 [com.mastodonc/faraday "1.10.0" :exclusions [com.amazonaws/aws-java-sdk-dynamodb
+                                                              com.taoensso/encore]]
                  [com.rpl/specter "1.0.3"]
                  [com.stuartsierra/component "0.3.2"]
-                 [com.taoensso/faraday "1.9.0" :exclusions [com.amazonaws/aws-java-sdk-dynamodb
-                                                            com.taoensso/encore]]
                  [com.taoensso/timbre "4.10.0"]
                  [com.taoensso/encore "2.92.0"]
                  [digest "1.4.6"]
                  [environ "1.1.0"]
-                 [kixi/kixi.comms "0.2.31"]
+                 [kixi/kixi.comms "0.2.31" :exclusions [amazonica]]
                  [kixi/kixi.log "0.1.5"]
                  [kixi/kixi.metrics "0.4.1"]
                  [kixi/joplin.core "0.3.10-SNAPSHOT"]
                  [kixi/joplin.dynamodb "0.3.10-SNAPSHOT"]
-                 [manifold "0.1.6-alpha1"]
+                 [manifold "0.1.6"]
                  [medley "1.0.0"]
                  [metrics-clojure ~metrics-version]
                  [metrics-clojure-jvm ~metrics-version]

--- a/src/kixi/datastore/filestore/command_handler.clj
+++ b/src/kixi/datastore/filestore/command_handler.clj
@@ -119,7 +119,8 @@
    init-multi-part-file-upload-creator-fn
    cache]
   (fn [cmd]
-    (if-not (s/valid? :kixi/command cmd)
+    (if (or (not (s/valid? :kixi/command cmd))
+            (not (::up/size-bytes cmd)))
       (fail-file-upload)
       (let [size-bytes (::up/size-bytes cmd)
             id (uuid)

--- a/src/kixi/datastore/filestore/migrators/dynamodb/migrator_20171221_ttl.clj
+++ b/src/kixi/datastore/filestore/migrators/dynamodb/migrator_20171221_ttl.clj
@@ -12,11 +12,11 @@
 
 (def ttl-col (db/dynamo-col ::fsu/ttl))
 
-(defn ten-mins-from-now
+(defn three-days-from-now
   []
   (t/in-seconds
    (t/interval (t/epoch)
-               (t/plus (t/now) (t/minutes 10)))))
+               (t/plus (t/now) (t/hours 72)))))
 
 (defn get-db-config
   [db]
@@ -41,7 +41,7 @@
                             (fsdb/primary-upload-cache-table profile)
                             fsdb/id-col
                             (:kixi.datastore.filestore_id %)
-                            {::fsu/ttl (ten-mins-from-now)}) items))))
+                            {::fsu/ttl (three-days-from-now)}) items))))
 (defn down
   [db]
   (let [profile (name @profile)

--- a/src/kixi/datastore/filestore/migrators/dynamodb/migrator_20171221_ttl.clj
+++ b/src/kixi/datastore/filestore/migrators/dynamodb/migrator_20171221_ttl.clj
@@ -1,0 +1,60 @@
+(ns kixi.datastore.filestore.migrators.dynamodb.migrator-20171221-ttl
+  (:require [kixi.datastore.system :refer [read-config]]
+            [kixi.datastore.application :refer [profile config-location]]
+            [kixi.datastore.filestore.upload-cache.dynamodb :as fsdb]
+            [kixi.datastore.filestore.upload :as fsu]
+            [kixi.datastore.filestore :as fs]
+            [kixi.datastore.dynamodb :as db]
+            [kixi.datastore.cloudwatch :refer [table-dynamo-alarms]]
+            [taoensso.faraday :as far]
+            [taoensso.timbre :as log]
+            [clj-time.core :as t]))
+
+(def ttl-col (db/dynamo-col ::fsu/ttl))
+
+(defn ten-mins-from-now
+  []
+  (t/in-seconds
+   (t/interval (t/epoch)
+               (t/plus (t/now) (t/minutes 10)))))
+
+(defn get-db-config
+  [db]
+  (select-keys db [:endpoint]))
+
+(defn get-alerts-config
+  [profile]
+  (:alerts (read-config @config-location profile)))
+
+(defn up
+  [db]
+  (let [profile (name @profile)
+        conn (get-db-config db)
+        items (not-empty (far/scan conn (fsdb/primary-upload-cache-table profile)))]
+    ;; Set ttl column
+    (when-not (= "local" profile)
+      (far/update-ttl conn (fsdb/primary-upload-cache-table profile) true ttl-col))
+    ;; Then add ttl column
+    (when items
+      (log/info "Adding" ::fsu/ttl "column to" (count items) "rows")
+      (run! #(db/merge-data conn
+                            (fsdb/primary-upload-cache-table profile)
+                            fsdb/id-col
+                            (:kixi.datastore.filestore_id %)
+                            {::fsu/ttl (ten-mins-from-now)}) items))))
+(defn down
+  [db]
+  (let [profile (name @profile)
+        conn (get-db-config db)
+        items (not-empty (far/scan conn (fsdb/primary-upload-cache-table profile)))]
+    ;; Set ttl column
+    (when-not (= "local" profile)
+      (far/update-ttl conn (fsdb/primary-upload-cache-table profile) false ttl-col))
+    ;; Then add ttl column
+    (when items
+      (log/info "Removing" ::fsu/ttl "column from" (count items) "rows")
+      (run! #(db/merge-data conn
+                            (fsdb/primary-upload-cache-table profile)
+                            fsdb/id-col
+                            (:kixi.datastore.filestore_id %)
+                            {::fsu/ttl nil}) items))))

--- a/src/kixi/datastore/filestore/migrators/dynamodb/migrator_20171221_ttl.clj
+++ b/src/kixi/datastore/filestore/migrators/dynamodb/migrator_20171221_ttl.clj
@@ -6,17 +6,11 @@
             [kixi.datastore.filestore :as fs]
             [kixi.datastore.dynamodb :as db]
             [kixi.datastore.cloudwatch :refer [table-dynamo-alarms]]
+            [kixi.datastore.time :as t]
             [taoensso.faraday :as far]
-            [taoensso.timbre :as log]
-            [clj-time.core :as t]))
+            [taoensso.timbre :as log]))
 
 (def ttl-col (db/dynamo-col ::fsu/ttl))
-
-(defn three-days-from-now
-  []
-  (t/in-seconds
-   (t/interval (t/epoch)
-               (t/plus (t/now) (t/hours 72)))))
 
 (defn get-db-config
   [db]
@@ -55,7 +49,7 @@
                             (fsdb/primary-upload-cache-table profile)
                             fsdb/id-col
                             (get % fsdb/id-col)
-                            {::fsu/ttl (three-days-from-now)}) items))))
+                            {::fsu/ttl (t/since-epoch (t/three-days-from-now))}) items))))
 (defn down
   [db]
   (let [profile (name @profile)

--- a/src/kixi/datastore/filestore/upload.clj
+++ b/src/kixi/datastore/filestore/upload.clj
@@ -17,4 +17,4 @@
 (s/def ::id string?)
 (s/def ::mup? boolean?)
 (s/def ::started-at sc/timestamp)
-(s/def ::finished-at sc/timestamp)
+(s/def ::ttl int?)

--- a/src/kixi/datastore/filestore/upload_cache/dynamodb.clj
+++ b/src/kixi/datastore/filestore/upload_cache/dynamodb.clj
@@ -24,7 +24,7 @@
     (put-item-fn {::fs/id file-id
                   ::up/id upload-id
                   ::up/mup? mup?
-                  ::up/ttl (t/since-epoch (t/add-hours (t/from-str created-at) 72))
+                  ::up/ttl (t/since-epoch (t/three-days-from-now (t/from-str created-at)))
                   :kixi/user user
                   ::up/created-at created-at}))
   (delete-item! [this file-id]

--- a/src/kixi/datastore/filestore/upload_cache/dynamodb.clj
+++ b/src/kixi/datastore/filestore/upload_cache/dynamodb.clj
@@ -24,7 +24,7 @@
     (put-item-fn {::fs/id file-id
                   ::up/id upload-id
                   ::up/mup? mup?
-                  ::up/ttl (t/since-epoch (t/add-hours (t/from-str created-at) 36))
+                  ::up/ttl (t/since-epoch (t/add-hours (t/from-str created-at) 72))
                   :kixi/user user
                   ::up/created-at created-at}))
   (delete-item! [this file-id]

--- a/src/kixi/datastore/filestore/upload_cache/dynamodb.clj
+++ b/src/kixi/datastore/filestore/upload_cache/dynamodb.clj
@@ -24,7 +24,7 @@
     (put-item-fn {::fs/id file-id
                   ::up/id upload-id
                   ::up/mup? mup?
-                  ::up/ttl (t/since-epoch (t/three-days-from-now (t/from-str created-at)))
+                  ::up/ttl (t/since-epoch (t/three-days-from (t/from-str created-at)))
                   :kixi/user user
                   ::up/created-at created-at}))
   (delete-item! [this file-id]

--- a/src/kixi/datastore/filestore/upload_cache/dynamodb.clj
+++ b/src/kixi/datastore/filestore/upload_cache/dynamodb.clj
@@ -24,6 +24,7 @@
     (put-item-fn {::fs/id file-id
                   ::up/id upload-id
                   ::up/mup? mup?
+                  ::up/ttl (t/since-epoch (t/add-hours (t/from-str created-at) 36))
                   :kixi/user user
                   ::up/created-at created-at}))
   (delete-item! [this file-id]

--- a/src/kixi/datastore/filestore/upload_cache/inmemory.clj
+++ b/src/kixi/datastore/filestore/upload_cache/inmemory.clj
@@ -16,6 +16,7 @@
              ::up/id upload-id
              ::up/mup? mup?
              :kixi/user user
+             ::up/ttl 0
              ::up/created-at created-at}]
       (log/info "Adding" m "for upload" file-id)
       (swap! cache assoc file-id m)))

--- a/src/kixi/datastore/time.clj
+++ b/src/kixi/datastore/time.clj
@@ -54,6 +54,12 @@
   [time hours]
   (t/plus time (t/hours hours)))
 
+(defn three-days-from-now
+  ([]
+   (three-days-from-now (t/now)))
+  ([time]
+   (add-hours time 72)))
+
 (defn since-epoch
   [time]
   (t/in-seconds

--- a/src/kixi/datastore/time.clj
+++ b/src/kixi/datastore/time.clj
@@ -49,3 +49,12 @@
        (zero? (t/hour x))
        (zero? (t/minute x))
        (zero? (t/milli x))))
+
+(defn add-hours
+  [time hours]
+  (t/plus time (t/hours hours)))
+
+(defn since-epoch
+  [time]
+  (t/in-seconds
+   (t/interval (t/epoch) time)))

--- a/src/kixi/datastore/time.clj
+++ b/src/kixi/datastore/time.clj
@@ -54,11 +54,13 @@
   [time hours]
   (t/plus time (t/hours hours)))
 
+(defn three-days-from
+  [time]
+  (add-hours time 72))
+
 (defn three-days-from-now
-  ([]
-   (three-days-from-now (t/now)))
-  ([time]
-   (add-hours time 72)))
+  []
+  (three-days-from (t/now)))
 
 (defn since-epoch
   [time]


### PR DESCRIPTION
In this PR we add `TTL` to the upload cache table. We have to provide a column which DynamoDB can use to calc TTL which is `kixi.datastore.filestore.upload/ttl` - this is applied to new rows but also retroactively applied to the cache as part of the migration.