### PR TITLE
Sharing updates allowed for tombstoned items

### DIFF
--- a/src/kixi/datastore/metadatastore/dynamodb.clj
+++ b/src/kixi/datastore/metadatastore/dynamodb.clj
@@ -131,10 +131,11 @@
                    [::md/sharing (::md/activity update-event)]
                    (:kixi.group/id update-event))
     (case (::md/sharing-update update-event)
-      ::md/sharing-conj (let [metadata (db/get-item conn
-                                                    (primary-metadata-table (:profile conn))
-                                                    id-col
-                                                    metadata-id)]
+      ::md/sharing-conj (let [metadata (db/get-item-ignore-tombstone
+                                        conn
+                                        (primary-metadata-table (:profile conn))
+                                        id-col
+                                        metadata-id)]
                           (insert-activity-row conn (:kixi.group/id update-event) (::md/activity update-event) metadata))
       ::md/sharing-disj (remove-activity-row conn (:kixi.group/id update-event) (::md/activity update-event) metadata-id))))
 


### PR DESCRIPTION
Introduces get-item-ignore-tombstone fn at the db layer, so updates to
the sharing matrix can occur for tombstoned items. This was
encountered as part of a patch to extract the bundle-add permission
from meta-update.