### PR TITLE
Revert "fix-up bundled-ids spec"

### DIFF
--- a/src/kixi/datastore/metadatastore.clj
+++ b/src/kixi/datastore/metadatastore.clj
@@ -47,7 +47,7 @@
 (s/def :kixi.user/groups (s/coll-of sc/uuid))
 
 (s/def ::bundle-type #{"datapack"})
-(s/def ::bundled-ids (s/coll-of sc/uuid :distinct true :into #{}))
+(s/def ::bundled-ids (s/coll-of sc/uuid :kind set?))
 
 (s/def :kixi/user
   (s/keys :req [:kixi.user/id


### PR DESCRIPTION
This reverts commit 7b52a12

We need to keep this a set, and alter kixi spec to respect this. i.e, the other way around.  Else we are effectively creating a new event type.