### PR TITLE
Rejected events use 'relaxed' versions of specs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -36,7 +36,7 @@
                  [com.taoensso/encore "2.92.0"]
                  [digest "1.4.6"]
                  [environ "1.1.0"]
-                 [kixi/kixi.comms "0.2.31" :exclusions [amazonica]]
+                 [kixi/kixi.comms "0.2.35" :exclusions [amazonica]]
                  [kixi/kixi.log "0.1.5"]
                  [kixi/kixi.metrics "0.4.1"]
                  [kixi/joplin.core "0.3.10-SNAPSHOT"]

--- a/src/kixi/datastore/metadatastore.clj
+++ b/src/kixi/datastore/metadatastore.clj
@@ -10,7 +10,10 @@
             [kixi.datastore.metadatastore.events]
             [kixi.datastore.metadatastore.commands]
             [kixi.datastore.schemastore.conformers :as sc]
+            [kixi.datastore.schemastore.utils :as sh]
             [clojure.spec.gen.alpha :as gen]))
+
+(sh/alias 'relaxed 'kixi.datastore.metadatastore.relaxed)
 
 (defn valid-file-name?
   "A file name should be at least one valid character long and only have valid characters and start with a digit or letter."
@@ -21,6 +24,7 @@
 (s/def ::type #{"stored" "bundle"})
 (s/def ::file-type sc/not-empty-string)
 (s/def ::id sc/uuid)
+(s/def ::relaxed/id string?)
 (s/def ::parent-id ::id)
 (s/def ::pieces-count int?)
 (s/def ::name (s/with-gen (s/and sc/not-empty-string valid-file-name?)
@@ -48,6 +52,7 @@
 
 (s/def ::bundle-type #{"datapack"})
 (s/def ::bundled-ids (s/coll-of sc/uuid :kind set?))
+(s/def ::relaxed/bundled-ids (s/coll-of any?))
 
 (s/def :kixi/user
   (s/keys :req [:kixi.user/id

--- a/src/kixi/datastore/metadatastore.clj
+++ b/src/kixi/datastore/metadatastore.clj
@@ -24,7 +24,7 @@
 (s/def ::type #{"stored" "bundle"})
 (s/def ::file-type sc/not-empty-string)
 (s/def ::id sc/uuid)
-(s/def ::relaxed/id string?)
+(s/def ::relaxed/id any?)
 (s/def ::parent-id ::id)
 (s/def ::pieces-count int?)
 (s/def ::name (s/with-gen (s/and sc/not-empty-string valid-file-name?)

--- a/src/kixi/datastore/metadatastore/command_handler.clj
+++ b/src/kixi/datastore/metadatastore/command_handler.clj
@@ -21,6 +21,7 @@
 (sh/alias 'kc 'kixi.comms.command)
 (sh/alias 'mdu 'kixi.datastore.metadatastore.update)
 (sh/alias 'kdm 'kixi.datastore.metadatastore)
+(sh/alias 'msr 'kixi.datastore.metadatastore.relaxed)
 (sh/alias 'kdfm 'kixi.datastore.file-metadata)
 
 (sh/alias 'event 'kixi.event)
@@ -383,7 +384,7 @@ the generated 'update' specs.
   [:kixi.datastore/delete-bundle "1.0.0"]
   [_]
   #{[:kixi.datastore/bundle-deleted "1.0.0"]
-    [:kixi.datastore/bundle-delete-rejected "1.0.0"]})
+    [:kixi.datastore/bundle-delete-rejected "2.0.0"]})
 
 (defn invalid-bundle-delete
   ([cmd reason id]
@@ -391,9 +392,9 @@ the generated 'update' specs.
   ([cmd reason id explain]
    [(merge
      {::event/type :kixi.datastore/bundle-delete-rejected
-      ::event/version "1.0.0"
+      ::event/version "2.0.0"
       :reason reason
-      ::ms/id id}
+      ::msr/id id}
      (when explain
        {:spec-explain explain}))
     {:partition-key id}]))
@@ -422,23 +423,19 @@ the generated 'update' specs.
   [:kixi.datastore/add-files-to-bundle "1.0.0"]
   [_]
   #{[:kixi.datastore/files-added-to-bundle "1.0.0"]
-    [:kixi.datastore/files-add-to-bundle-rejected "1.0.0"]})
+    [:kixi.datastore/files-add-to-bundle-rejected "2.0.0"]})
 
 (defn reject-add-files-to-bundle
   ([cmd reason id bundled-ids]
-   [{::event/type :kixi.datastore/files-add-to-bundle-rejected
-     ::event/version "1.0.0"
-     :reason reason
-     ::ms/id id
-     ::ms/bundled-ids bundled-ids}
-    {:partition-key id}])
+   (reject-add-files-to-bundle cmd reason id bundled-ids nil))
   ([cmd reason id bundled-ids explain]
-   [{::event/type :kixi.datastore/files-add-to-bundle-rejected
-     ::event/version "1.0.0"
-     :reason reason
-     ::ms/id id
-     ::ms/bundled-ids bundled-ids
-     :spec-explain explain}
+   [(merge {::event/type :kixi.datastore/files-add-to-bundle-rejected
+            ::event/version "2.0.0"
+            :reason reason
+            ::msr/id id
+            ::msr/bundled-ids bundled-ids}
+           (when explain
+             {:spec-explain explain}))
     {:partition-key id}]))
 
 (defn create-add-files-to-bundle-handler

--- a/src/kixi/datastore/metadatastore/events.clj
+++ b/src/kixi/datastore/metadatastore/events.clj
@@ -7,6 +7,7 @@
 (sh/alias 'cmd 'kixi.command)
 (sh/alias 'user 'kixi.user)
 (sh/alias 'md 'kixi.datastore.metadatastore)
+(sh/alias 'mdr 'kixi.datastore.metadatastore.relaxed)
 
 (s/def ::spec-explain any?)
 
@@ -58,6 +59,13 @@
           :opt-un [::spec-explain]))
 
 (defmethod comms/event-payload
+  [:kixi.datastore/bundle-delete-rejected "2.0.0"]
+  [_]
+  (s/keys :req [::mdr/id]
+          :req-un [::dd-reject/reason]
+          :opt-un [::spec-explain]))
+
+(defmethod comms/event-payload
   [:kixi.datastore/files-added-to-bundle "1.0.0"]
   [_]
   (s/keys :req [::md/id
@@ -75,6 +83,14 @@
   [_]
   (s/keys :req [::md/id
                 ::md/bundled-ids]
+          :req-un [::fab-reject/reason]
+          :opt-un [::spec-explain]))
+
+(defmethod comms/event-payload
+  [:kixi.datastore/files-add-to-bundle-rejected "2.0.0"]
+  [_]
+  (s/keys :req [::mdr/id
+                ::mdr/bundled-ids]
           :req-un [::fab-reject/reason]
           :opt-un [::spec-explain]))
 

--- a/test/kixi/integration/datapack_update_test.clj
+++ b/test/kixi/integration/datapack_update_test.clj
@@ -1,6 +1,8 @@
 (ns kixi.integration.datapack-update-test
   {:integration true}
   (:require [clojure.test :refer :all]
+            [clojure.spec.alpha :as s]
+            [kixi.comms :as c]
             [kixi.datastore
              [metadatastore :as ms]
              [schemastore :as ss]]
@@ -101,6 +103,13 @@
                              (is (= 1
                                     only-file-visible-cnt)))))))))
 
+(deftest bundle-delete-invalid-cmd-rejected
+  (let [response-event (binding [c/*validate-commands* false]
+                         (send-bundle-delete (uuid) "foobar"))]
+    (when-event-type response-event :kixi.datastore/bundle-delete-rejected
+                     (is (= :invalid-cmd
+                            (:reason response-event))))))
+
 (deftest bundle-delete-unauthorised-rejected
   (let [uid (uuid)
         datapack-resp (small-file-into-datapack uid)]
@@ -125,6 +134,12 @@
                          (is (= 200
                                 (:status (get-metadata uid file-meta-id)))))))))
 
+(deftest add-files-to-bundle-invalid-cmd-rejected
+  (let [response-event (binding [c/*validate-commands* false]
+                         (send-add-files-to-bundle (uuid) "12345" #{"foobar"}))] ;; invalid id
+    (when-event-type response-event :kixi.datastore/files-add-to-bundle-rejected
+                     (is (= :invalid-cmd
+                            (:reason response-event))))))
 
 (deftest ^:acceptance add-files-to-bundle-incorrect-type-rejected
   (let [uid (uuid)


### PR DESCRIPTION
**Rejected events use 'relaxed' versions of specs**
In the instance that a command is received and deemed to be invalid,
we cannot simply pass data through; it should be assumed that all data
is garbage, unparse-able etc. In this case, it only makes sense to use
less strict spec when we send out 'rejected' events that typically
reference this data.