### PR TITLE
Add new format commands and events for sharing alterations

### DIFF
--- a/src/kixi/datastore/communication_specs.clj
+++ b/src/kixi/datastore/communication_specs.clj
@@ -16,7 +16,6 @@
 
 (s/def ::version (s/and string? #(re-matches #"\d+\.\d+\.\d+" %)))
 
-
 (defmulti file-metadata-updated-type ::file-metadata-update-type)
 
 (defmethod file-metadata-updated-type ::file-metadata-created

--- a/src/kixi/datastore/metadatastore.clj
+++ b/src/kixi/datastore/metadatastore.clj
@@ -158,6 +158,9 @@
 
 (s/def ::sharing-update #{::sharing-conj ::sharing-disj})
 
+(s/def ::sharing-change-payload
+  (s/keys :req [::id ::sharing-update :kixi.group/id ::activity]))
+
 (defprotocol MetaDataStore
   (authorised
     [this action id user-groups])

--- a/src/kixi/datastore/metadatastore/command_handler.clj
+++ b/src/kixi/datastore/metadatastore/command_handler.clj
@@ -224,16 +224,6 @@
                                   :kixi/user (::kc/user cmd)}
                                  payload))))))
 
-(defn get-spec-keys
-  [spec]
-  (->> spec
-       (s/get-spec)
-       (s/form)
-       (rest)
-       (drop 1)
-       (take-nth 2)
-       (reduce concat)))
-
 (defn create-sharing-change-handler
   [metadatastore]
   (let [authorised (partial ms/authorised metadatastore ::ms/meta-update)]

--- a/src/kixi/datastore/metadatastore/command_handler.clj
+++ b/src/kixi/datastore/metadatastore/command_handler.clj
@@ -241,7 +241,7 @@
       (cond
         (not (spec/valid? :kixi/command cmd)) (sharing-change-invalid cmd)
         (not (authorised (::ms/id cmd) (get-user-groups cmd))) (sharing-change-unauthorised cmd)
-        :default (sharing-changed (select-keys cmd (get-spec-keys ::ms/sharing-change-payload)))))))
+        :default (sharing-changed (select-keys cmd [::ms/id ::ms/sharing-update :kixi.group/id ::ms/activity]))))))
 
 (defmulti metadata-update
   (fn [payload]

--- a/src/kixi/datastore/metadatastore/commands.clj
+++ b/src/kixi/datastore/metadatastore/commands.clj
@@ -28,3 +28,8 @@
   [_]
   (s/keys :req [::md/id
                 ::md/bundled-ids]))
+
+(defmethod comms/command-payload
+  [:kixi.datastore/sharing-change "2.0.0"]
+  [_]
+  ::md/sharing-change-payload)

--- a/src/kixi/datastore/metadatastore/dynamodb.clj
+++ b/src/kixi/datastore/metadatastore/dynamodb.clj
@@ -116,7 +116,7 @@
                            [::md/segmentations]
                            (:kixi.group/id update-event))))
 
-(defn update-sharing!
+(defn update-sharing
   [conn update-event]
   (info "Update Share: " update-event)
   (let [update-fn (case (::md/sharing-update update-event)
@@ -141,7 +141,7 @@
 
 (defmethod update-metadata-processor ::cs/file-metadata-sharing-updated
   [conn update-event]
-  (update-sharing! conn update-event))
+  (update-sharing conn update-event))
 
 (defn dissoc-nonupdates
   [md]
@@ -165,7 +165,7 @@
 (defn sharing-changed-handler
   [client]
   (fn [event]
-    (update-sharing! client event)))
+    (update-sharing client event)))
 
 (defn file-deleted-handler
   [client]
@@ -362,7 +362,6 @@
                                  :kixi.datastore.file-metadata/updated
                                  "1.0.0"
                                  (comp response-event (partial update-metadata-processor client) :kixi.comms.event/payload))
-        ;;
         (c/attach-validating-event-handler! communications
                                             :kixi.datastore/metadatastore
                                             :kixi.datastore/sharing-changed

--- a/src/kixi/datastore/metadatastore/dynamodb.clj
+++ b/src/kixi/datastore/metadatastore/dynamodb.clj
@@ -108,15 +108,15 @@
   [conn update-event]
   (info "Update: " update-event)
   (comment "This implementation is not idempotent, need a check to prevent repeat segement adds"
-    (db/append-list conn
-                    (primary-metadata-table (:profile conn))
-                    id-col
-                    (::md/id update-event)
-                    :add
-                    [::md/segmentations]
-                    (:kixi.group/id update-event))))
+           (db/append-list conn
+                           (primary-metadata-table (:profile conn))
+                           id-col
+                           (::md/id update-event)
+                           :add
+                           [::md/segmentations]
+                           (:kixi.group/id update-event))))
 
-(defmethod update-metadata-processor ::cs/file-metadata-sharing-updated
+(defn update-sharing!
   [conn update-event]
   (info "Update Share: " update-event)
   (let [update-fn (case (::md/sharing-update update-event)
@@ -139,6 +139,10 @@
                           (insert-activity-row conn (:kixi.group/id update-event) (::md/activity update-event) metadata))
       ::md/sharing-disj (remove-activity-row conn (:kixi.group/id update-event) (::md/activity update-event) metadata-id))))
 
+(defmethod update-metadata-processor ::cs/file-metadata-sharing-updated
+  [conn update-event]
+  (update-sharing! conn update-event))
+
 (defn dissoc-nonupdates
   [md]
   (reduce
@@ -157,6 +161,11 @@
                   id-col
                   (::md/id update-event)
                   (dissoc-nonupdates update-event)))
+
+(defn sharing-changed-handler
+  [client]
+  (fn [event]
+    (update-sharing! client event)))
 
 (defn file-deleted-handler
   [client]
@@ -353,6 +362,12 @@
                                  :kixi.datastore.file-metadata/updated
                                  "1.0.0"
                                  (comp response-event (partial update-metadata-processor client) :kixi.comms.event/payload))
+        ;;
+        (c/attach-validating-event-handler! communications
+                                            :kixi.datastore/metadatastore
+                                            :kixi.datastore/sharing-changed
+                                            "1.0.0"
+                                            (sharing-changed-handler client))
         (c/attach-validating-event-handler! communications
                                             :kixi.datastore/metadatastore-file-delete
                                             :kixi.datastore/file-deleted

--- a/src/kixi/datastore/metadatastore/events.clj
+++ b/src/kixi/datastore/metadatastore/events.clj
@@ -115,3 +115,27 @@
                 ::md/bundled-ids]
           :req-un [::fab-reject/reason]
           :opt-un [::spec-explain]))
+
+(sh/alias 'sharing-reject 'kixi.event.metadata.sharing-change.rejection)
+
+(s/def ::sharing-reject/reason
+  #{:unauthorised
+    :invalid-cmd})
+
+(s/def ::sharing-reject/explain string?)
+(s/def ::sharing-reject/original any?)
+
+(defmethod comms/event-payload
+  [:kixi.datastore/sharing-change-rejected "2.0.0"]
+  [_]
+  (s/keys :req [::sharing-reject/reason]
+          :opt [::sharing-reject/explain
+                ::sharing-reject/original
+                ::md/id]))
+
+;;
+
+(defmethod comms/event-payload
+  [:kixi.datastore/sharing-changed "1.0.0"]
+  [_]
+  ::md/sharing-change-payload)


### PR DESCRIPTION
* `:kixi.datastore/sharing-change` command (cousin of `:kixi.datastore.metadatastore/sharing-change`)
* `:kixi.datastore/sharing-changed` event (cousin of `:kixi.datastore.file-metadata/updated`)
* `:kixi.datastore/sharing-change-rejected` event (cousin of `:kixi.datastore.metadatastore/sharing-change-rejected`)

As much as possible, the old code paths have been adapted, although very little is needed as the `payload` of the original commands/events is the spec of the new commands/events. Tests have also been added to ensure the old code paths and old commands/events are still working. Until the old commands/events are truly deprecated, there might be parts of the system still using them.