### PR TITLE
Bring datastore up to speed with kixi.spec

### DIFF
--- a/src/kixi/datastore/metadatastore.clj
+++ b/src/kixi/datastore/metadatastore.clj
@@ -127,7 +127,7 @@
 (defmulti file-metadata ::type)
 
 (s/def ::tags
-  (s/coll-of sc/not-empty-string :distinct true :into #{}))
+  (s/coll-of sc/not-empty-string :kind set))
 
 (defmethod file-metadata "stored"
   [_]

--- a/test/kixi/integration/metadata_update_test.clj
+++ b/test/kixi/integration/metadata_update_test.clj
@@ -338,36 +338,6 @@
                                             (is (= #{"orig2" "Tag2" "Tag3"}
                                                    (get-in updated-metadata [:body ::ms/tags])))))))))))
 
-(deftest small-file-update-tags-list
-  (let [uid (uuid)
-        metadata-response (send-file-and-metadata
-                           (assoc (create-metadata
-                                   uid
-                                   "./test-resources/metadata-one-valid.csv")
-                                  ::ms/tags #{"orig1" "orig2"}))]
-    (when-success metadata-response
-      (let [meta-id (get-in metadata-response [:body ::ms/id])
-            event (update-metadata
-                   uid meta-id
-                   {:kixi.datastore.metadatastore.update/tags {:conj ["Tag1" "Tag2" "Tag3"]}})]
-        (when-event-key event :kixi.datastore.file-metadata/updated
-                        (wait-for-pred #(let [metadata (get-metadata uid meta-id)]
-                                          (= #{"orig1" "orig2" "Tag1" "Tag2" "Tag3"}
-                                             (get-in metadata [:body ::ms/tags]))))
-                        (let [updated-metadata (get-metadata uid meta-id)]
-                          (is (= #{"orig1" "orig2" "Tag1" "Tag2" "Tag3"}
-                                 (get-in updated-metadata [:body ::ms/tags]))))
-                        (let [disj-event (update-metadata
-                                          uid meta-id
-                                          {:kixi.datastore.metadatastore.update/tags {:disj ["Tag1" "orig1"]}})]
-                          (when-event-key disj-event :kixi.datastore.file-metadata/updated
-                                          (wait-for-pred #(let [metadata (get-metadata uid meta-id)]
-                                                            (= #{"orig2" "Tag2" "Tag3"}
-                                                               (get-in metadata [:body ::ms/tags]))))
-                                          (let [updated-metadata (get-metadata uid meta-id)]
-                                            (is (= #{"orig2" "Tag2" "Tag3"}
-                                                   (get-in updated-metadata [:body ::ms/tags])))))))))))
-
 (deftest ^:acceptance small-file-update-license-type
   (let [uid (uuid)
         metadata-response (send-file-and-metadata


### PR DESCRIPTION
The steer to use strong typing brings tags up to date with kixi.spec.